### PR TITLE
Update triming of '-theme' to use string replace to avoid removing 'e…

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -224,7 +224,7 @@ module.exports = function(options) {
 				return cb();
 			}
 
-			var themeId = _.trimRight(lfrThemeConfig.getConfig(true).name, '-theme');
+			var themeId = lfrThemeConfig.getConfig(true).name.replace(/(?:-theme)+$/i, '');
 
 			lookAndFeelUtil.correctJSONIdentifiers(lookAndFeelJSON, themeId);
 


### PR DESCRIPTION
…' when used as 'e-theme'