### PR TITLE
Fix timestamp issue at @import css inline theme 6.2 

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -156,7 +156,9 @@ module.exports = function(options) {
 					{
 						match: /@import\s+url\s*\(\s*['\"]?(.+\.css)['\"]?/g,
 						replacement: function(match, m1) {
-							return '@import url(' + m1 + '?t=' + Date.now();
+							return themeConfig.version === '6.2' ?
+									'@import url(' + m1 :
+									'@import url(' + m1 + '?t=' + Date.now();
 						}
 					}
 				]


### PR DESCRIPTION
Checking the theme version is 6.2 to not include the timestamp in the @import of css files.