### PR TITLE
Proposed solution to issue #87 gulp extend published npm themelet not working

### DIFF
--- a/lib/prompts/extend_prompt.js
+++ b/lib/prompts/extend_prompt.js
@@ -172,9 +172,24 @@ ExtendPrompt.prototype = {
 	},
 
 	_getDistTag: function(config, version, prefix) {
-		var supportedVersion = config.liferayTheme.version;
-
 		var tag = prefix || '';
+		var supportedVersion = '';
+
+		if(config.hasOwnProperty('liferayTheme')) {
+			supportedVersion = config.liferayTheme.version;
+		}
+		else {
+			var liferayTheme = config.versions[Object.keys(config.versions)[0]].liferayTheme;
+			supportedVersion = liferayTheme.version;
+		}
+
+		if (this._isSupported(supportedVersion, version) && this._hasPublishTag(config)) {
+			tag += version.replace('.', '_') + '_x';
+		}
+		else {
+			tag += '*';
+		}
+		var supportedVersion = config.liferayTheme.version;
 
 		if (this._isSupported(supportedVersion, version) && this._hasPublishTag(config)) {
 			tag += version.replace('.', '_') + '_x';
@@ -294,7 +309,7 @@ ExtendPrompt.prototype = {
 	_reducePkgData: function(pkg) {
 		var realPath = pkg.realPath;
 
-		pkg = _.pick(pkg, ['liferayTheme', 'name', 'publishConfig', 'version']);
+		pkg = _.pick(pkg, ['liferayTheme', 'name', 'publishConfig', 'repository', 'version', 'versions']);
 
 		if (realPath) {
 			pkg.path = realPath;

--- a/lib/prompts/extend_prompt.js
+++ b/lib/prompts/extend_prompt.js
@@ -179,17 +179,12 @@ ExtendPrompt.prototype = {
 			supportedVersion = config.liferayTheme.version;
 		}
 		else {
-			var liferayTheme = config.versions[Object.keys(config.versions)[0]].liferayTheme;
-			supportedVersion = liferayTheme.version;
+            var ifMultipleVersions = config.versions[Object.keys(config.versions)[0]];
+            if (ifMultipleVersions.hasOwnProperty('liferayTheme')) {
+                var liferayTheme = ifMultipleVersions.liferayTheme;
+                supportedVersion = liferayTheme.version;
+            }
 		}
-
-		if (this._isSupported(supportedVersion, version) && this._hasPublishTag(config)) {
-			tag += version.replace('.', '_') + '_x';
-		}
-		else {
-			tag += '*';
-		}
-		var supportedVersion = config.liferayTheme.version;
 
 		if (this._isSupported(supportedVersion, version) && this._hasPublishTag(config)) {
 			tag += version.replace('.', '_') + '_x';

--- a/lib/theme_finder.js
+++ b/lib/theme_finder.js
@@ -17,43 +17,32 @@ module.exports = {
 		this._getPackageJSON({
 			name: name
 		}, function(err, pkg) {
-            console.log("getLiferayThemeModule ----------------------------------");
-            console.log("INPUT --------------------------------------------------");
+			var isNotLiferayModuleError = new Error('Package is not a Liferay theme or themelet module');
+			var isNullPkgError = new Error('Package or version doesn\'t exist');
 
-            var isNotLiferayModuleError = new Error('Package is not a Liferay theme or themelet module');
-            var isNullPkgError = new Error('Package is null');
+			if((!_.isUndefined(pkg)) && (!_.isNull(pkg))) {
+				if(pkg.hasOwnProperty('versions')){
+					var keys = Object.keys(pkg.versions).sort().reverse();
+					var ifMultipleVersions = pkg.versions[keys[0]];
 
-			if((_.isUndefined(pkg)) && (!_.isNull(pkg))) {
-                console.log('not null');
-                if(pkg.hasOwnProperty('versions')){
-                    console.log('has multiple versions');
-                    var keys = Object.keys(pkg.versions);
-                    var ifMultipleVersions = pkg.versions[keys[0]];
+					if (!ifMultipleVersions.hasOwnProperty('liferayTheme') || !_.contains(ifMultipleVersions.keywords, 'liferay-theme')) {
+						pkg = null;
 
-                    if (!ifMultipleVersions.hasOwnProperty('liferayTheme') || !_.contains(ifMultipleVersions.keywords, 'liferay-theme')) {
-                        console.log('isnt Liferay module');
-                        pkg = null;
-
-                        err = isNotLiferayModuleError;
+						err = isNotLiferayModuleError;
+					} else {
+						pkg = ifMultipleVersions;
 					}
 				} else if (!pkg.hasOwnProperty('liferayTheme') || !_.contains(pkg.keywords, 'liferay-theme')) {
-                    console.log('isnt Liferay module');
-                    pkg = null;
+					pkg = null;
 
-                    err = isNotLiferayModuleError;
-                } else {
-                    console.log('pkg OK');
+					err = isNotLiferayModuleError;
 				}
 			} else {
-				console.log('null package');
-                err = isNullPkgError;
+				err = isNullPkgError;
 			}
 
-            console.log('RETURN -------------------------------------------------');
-            console.log(err);
-
 			cb(err, pkg);
-        });
+		});
 	},
 
 	getLiferayThemeModules: function(config, cb) {
@@ -66,8 +55,6 @@ module.exports = {
 		var globalModules = _.isUndefined(config.globalModules) ? true : config.globalModules;
 
 		config.keyword = config.keyword || config.searchTerms || 'liferay-theme';
-
-		console.log(globalModules ? 'global' : 'npm_search');
 
 		var searchFn = globalModules ? this._seachGlobalModules : this._searchNpm;
 

--- a/lib/theme_finder.js
+++ b/lib/theme_finder.js
@@ -17,14 +17,43 @@ module.exports = {
 		this._getPackageJSON({
 			name: name
 		}, function(err, pkg) {
-			if ((pkg && !pkg.liferayTheme) || (pkg && !_.contains(pkg.keywords, 'liferay-theme'))) {
-				pkg = null;
+            console.log("getLiferayThemeModule ----------------------------------");
+            console.log("INPUT --------------------------------------------------");
 
-				err = new Error('Package is not a Liferay theme or themelet module');
+            var isNotLiferayModuleError = new Error('Package is not a Liferay theme or themelet module');
+            var isNullPkgError = new Error('Package is null');
+
+			if((_.isUndefined(pkg)) && (!_.isNull(pkg))) {
+                console.log('not null');
+                if(pkg.hasOwnProperty('versions')){
+                    console.log('has multiple versions');
+                    var keys = Object.keys(pkg.versions);
+                    var ifMultipleVersions = pkg.versions[keys[0]];
+
+                    if (!ifMultipleVersions.hasOwnProperty('liferayTheme') || !_.contains(ifMultipleVersions.keywords, 'liferay-theme')) {
+                        console.log('isnt Liferay module');
+                        pkg = null;
+
+                        err = isNotLiferayModuleError;
+					}
+				} else if (!pkg.hasOwnProperty('liferayTheme') || !_.contains(pkg.keywords, 'liferay-theme')) {
+                    console.log('isnt Liferay module');
+                    pkg = null;
+
+                    err = isNotLiferayModuleError;
+                } else {
+                    console.log('pkg OK');
+				}
+			} else {
+				console.log('null package');
+                err = isNullPkgError;
 			}
 
+            console.log('RETURN -------------------------------------------------');
+            console.log(err);
+
 			cb(err, pkg);
-		});
+        });
 	},
 
 	getLiferayThemeModules: function(config, cb) {
@@ -37,6 +66,8 @@ module.exports = {
 		var globalModules = _.isUndefined(config.globalModules) ? true : config.globalModules;
 
 		config.keyword = config.keyword || config.searchTerms || 'liferay-theme';
+
+		console.log(globalModules ? 'global' : 'npm_search');
 
 		var searchFn = globalModules ? this._seachGlobalModules : this._searchNpm;
 
@@ -106,7 +137,7 @@ module.exports = {
 	},
 
 	_getPackageJSON: function(theme, cb) {
-		packageJson(theme.name, '*', function(err, pkg) {
+		packageJson(theme.name, '', function(err, pkg) {
 			if (err) {
 				cb(err);
 
@@ -121,16 +152,20 @@ module.exports = {
 		var retVal = false;
 		var liferayTheme = null;
 
-		if (pkg) {
+		if ((_.isUndefined(pkg)) && (!_.isNull(pkg))) {
 
 			if(pkg.hasOwnProperty('liferayTheme')) {
 				liferayTheme = pkg.liferayTheme;
 			}
-			else {
-				liferayTheme = pkg.versions[Object.keys(pkg.versions)[0]].liferayTheme;
+			else if(pkg.hasOwnProperty('versions')) {
+				var keys = Object.keys(pkg.versions);
+				var ifMultipleVersions = pkg.versions[keys[0]];
+				if (ifMultipleVersions.hasOwnProperty('liferayTheme')) {
+					liferayTheme = ifMultipleVersions.liferayTheme;
+				}
 			}
 
-			if (liferayTheme) {
+			if ((liferayTheme !== null) && (liferayTheme.hasOwnProperty('version'))) {
 				var liferayThemeVersion = liferayTheme.version;
 				if (_.isArray(liferayThemeVersion) && !_.contains(liferayThemeVersion, themeConfig.version)) {
 					return retVal;
@@ -193,7 +228,7 @@ module.exports = {
 			}
 
 			return result;
-		}, []);
+		}, {});
 
 		cb(instance._reduceModuleResults(modules, config));
 	},

--- a/lib/theme_finder.js
+++ b/lib/theme_finder.js
@@ -36,7 +36,7 @@ module.exports = {
 
 		var globalModules = _.isUndefined(config.globalModules) ? true : config.globalModules;
 
-		config.keyword = config.keyword || 'liferay-theme';
+		config.keyword = config.keyword || config.searchTerms || 'liferay-theme';
 
 		var searchFn = globalModules ? this._seachGlobalModules : this._searchNpm;
 
@@ -119,24 +119,27 @@ module.exports = {
 
 	_isLiferayThemeModule: function(pkg, themelet) {
 		var retVal = false;
+		var liferayTheme = null;
 
 		if (pkg) {
-			var liferayTheme = pkg.liferayTheme;
 
-			if (!liferayTheme) {
-				return retVal;
+			if(pkg.hasOwnProperty('liferayTheme')) {
+				liferayTheme = pkg.liferayTheme;
+			}
+			else {
+				liferayTheme = pkg.versions[Object.keys(pkg.versions)[0]].liferayTheme;
 			}
 
-			var liferayThemeVersion = liferayTheme.version;
-
-			if (_.isArray(liferayThemeVersion) && !_.contains(liferayThemeVersion, themeConfig.version)) {
-				return retVal;
+			if (liferayTheme) {
+				var liferayThemeVersion = liferayTheme.version;
+				if (_.isArray(liferayThemeVersion) && !_.contains(liferayThemeVersion, themeConfig.version)) {
+					return retVal;
+				}
+				else if (!_.isArray(liferayThemeVersion) && (liferayThemeVersion !== '*') && (liferayThemeVersion !== themeConfig.version)) {
+					return retVal;
+				}
+				retVal = liferayTheme && (themelet ? liferayTheme.themelet : !liferayTheme.themelet);
 			}
-			else if (!_.isArray(liferayThemeVersion) && (liferayThemeVersion !== '*') && (liferayThemeVersion !== themeConfig.version)) {
-				return retVal;
-			}
-
-			retVal = liferayTheme && (themelet ? liferayTheme.themelet : !liferayTheme.themelet);
 		}
 
 		return retVal;

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "amdefine": {
@@ -42,7 +42,7 @@
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
       "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       }
     },
     "ansi-escapes": {
@@ -67,8 +67,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11"
+        "arrify": "^1.0.0",
+        "micromatch": "^2.1.5"
       }
     },
     "applause": {
@@ -76,9 +76,9 @@
       "resolved": "https://registry.npmjs.org/applause/-/applause-0.4.3.tgz",
       "integrity": "sha1-Zmy9fw+c5U3L3mcM7qguYTORvb0=",
       "requires": {
-        "cson-parser": "1.3.5",
-        "js-yaml": "3.8.4",
-        "lodash": "3.10.1"
+        "cson-parser": "^1.0.9",
+        "js-yaml": "^3.0.0",
+        "lodash": "^3.0.0"
       }
     },
     "aproba": {
@@ -98,8 +98,8 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.2.11"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -107,7 +107,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -115,7 +115,7 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "requires": {
-        "arr-flatten": "1.0.3"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-exclude": {
@@ -144,7 +144,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -210,78 +210,78 @@
       "integrity": "sha1-UUu12GpxsClDUfgDoT3bDCfHu2I=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "arr-flatten": "1.0.3",
-        "array-union": "1.0.2",
-        "array-uniq": "1.0.3",
-        "arrify": "1.0.1",
-        "ava-init": "0.1.6",
-        "babel-code-frame": "6.22.0",
-        "babel-core": "6.25.0",
+        "arr-diff": "^2.0.0",
+        "arr-flatten": "^1.0.1",
+        "array-union": "^1.0.1",
+        "array-uniq": "^1.0.2",
+        "arrify": "^1.0.0",
+        "ava-init": "^0.1.0",
+        "babel-code-frame": "^6.7.5",
+        "babel-core": "^6.3.21",
         "babel-plugin-ava-throws-helper": "0.0.4",
-        "babel-plugin-detective": "1.0.2",
-        "babel-plugin-espower": "2.3.2",
-        "babel-plugin-transform-runtime": "6.23.0",
-        "babel-preset-es2015": "6.24.1",
-        "babel-preset-stage-2": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "bluebird": "3.5.0",
-        "caching-transform": "1.0.1",
-        "chalk": "1.1.3",
-        "chokidar": "1.7.0",
-        "clean-yaml-object": "0.1.0",
-        "cli-cursor": "1.0.2",
-        "cli-spinners": "0.1.2",
-        "cli-truncate": "0.2.1",
-        "co-with-promise": "4.6.0",
-        "common-path-prefix": "1.0.0",
-        "convert-source-map": "1.5.0",
-        "core-assert": "0.2.1",
-        "currently-unhandled": "0.4.1",
-        "debug": "2.6.8",
-        "empower-core": "0.5.0",
-        "figures": "1.7.0",
-        "find-cache-dir": "0.1.1",
-        "fn-name": "2.0.1",
-        "globby": "4.1.0",
-        "has-flag": "2.0.0",
-        "ignore-by-default": "1.0.1",
-        "is-ci": "1.0.10",
-        "is-generator-fn": "1.0.0",
-        "is-obj": "1.0.1",
-        "is-observable": "0.2.0",
-        "is-promise": "2.1.0",
-        "last-line-stream": "1.0.0",
-        "lodash.debounce": "4.0.8",
-        "loud-rejection": "1.6.0",
-        "matcher": "0.1.2",
-        "max-timeout": "1.0.0",
-        "md5-hex": "1.3.0",
-        "meow": "3.7.0",
-        "ms": "0.7.3",
-        "multimatch": "2.1.0",
-        "not-so-shallow": "0.1.4",
-        "object-assign": "4.1.1",
-        "observable-to-promise": "0.4.0",
-        "option-chain": "0.1.1",
-        "package-hash": "1.2.0",
-        "pkg-conf": "1.1.3",
-        "plur": "2.1.2",
-        "power-assert-formatter": "1.4.1",
-        "power-assert-renderers": "0.1.1",
-        "pretty-ms": "2.1.0",
-        "repeating": "2.0.1",
-        "require-precompiled": "0.1.0",
-        "resolve-cwd": "1.0.0",
-        "set-immediate-shim": "1.0.1",
-        "slash": "1.0.0",
-        "source-map-support": "0.4.15",
-        "stack-utils": "0.4.0",
-        "strip-ansi": "3.0.1",
-        "strip-bom": "2.0.0",
-        "time-require": "0.1.2",
-        "unique-temp-dir": "1.0.0",
-        "update-notifier": "0.7.0"
+        "babel-plugin-detective": "^1.0.2",
+        "babel-plugin-espower": "^2.1.0",
+        "babel-plugin-transform-runtime": "^6.3.13",
+        "babel-preset-es2015": "^6.3.13",
+        "babel-preset-stage-2": "^6.3.13",
+        "babel-runtime": "^6.3.19",
+        "bluebird": "^3.0.0",
+        "caching-transform": "^1.0.0",
+        "chalk": "^1.0.0",
+        "chokidar": "^1.4.2",
+        "clean-yaml-object": "^0.1.0",
+        "cli-cursor": "^1.0.2",
+        "cli-spinners": "^0.1.2",
+        "cli-truncate": "^0.2.0",
+        "co-with-promise": "^4.6.0",
+        "common-path-prefix": "^1.0.0",
+        "convert-source-map": "^1.2.0",
+        "core-assert": "^0.2.0",
+        "currently-unhandled": "^0.4.1",
+        "debug": "^2.2.0",
+        "empower-core": "^0.5.0",
+        "figures": "^1.4.0",
+        "find-cache-dir": "^0.1.1",
+        "fn-name": "^2.0.0",
+        "globby": "^4.0.0",
+        "has-flag": "^2.0.0",
+        "ignore-by-default": "^1.0.0",
+        "is-ci": "^1.0.7",
+        "is-generator-fn": "^1.0.0",
+        "is-obj": "^1.0.0",
+        "is-observable": "^0.2.0",
+        "is-promise": "^2.1.0",
+        "last-line-stream": "^1.0.0",
+        "lodash.debounce": "^4.0.3",
+        "loud-rejection": "^1.2.0",
+        "matcher": "^0.1.1",
+        "max-timeout": "^1.0.0",
+        "md5-hex": "^1.2.0",
+        "meow": "^3.7.0",
+        "ms": "^0.7.1",
+        "multimatch": "^2.1.0",
+        "not-so-shallow": "^0.1.3",
+        "object-assign": "^4.0.1",
+        "observable-to-promise": "^0.4.0",
+        "option-chain": "^0.1.0",
+        "package-hash": "^1.1.0",
+        "pkg-conf": "^1.0.1",
+        "plur": "^2.0.0",
+        "power-assert-formatter": "^1.3.0",
+        "power-assert-renderers": "^0.1.0",
+        "pretty-ms": "^2.0.0",
+        "repeating": "^2.0.0",
+        "require-precompiled": "^0.1.0",
+        "resolve-cwd": "^1.0.0",
+        "set-immediate-shim": "^1.0.1",
+        "slash": "^1.0.0",
+        "source-map-support": "^0.4.0",
+        "stack-utils": "^0.4.0",
+        "strip-ansi": "^3.0.1",
+        "strip-bom": "^2.0.0",
+        "time-require": "^0.1.2",
+        "unique-temp-dir": "^1.0.0",
+        "update-notifier": "^0.7.0"
       },
       "dependencies": {
         "boxen": {
@@ -290,14 +290,14 @@
           "integrity": "sha1-W3PYhA6388ihVcv2ntPtaNRyABQ=",
           "dev": true,
           "requires": {
-            "camelcase": "2.1.1",
-            "chalk": "1.1.3",
-            "cli-boxes": "1.0.0",
-            "filled-array": "1.1.0",
-            "object-assign": "4.1.1",
-            "repeating": "2.0.1",
-            "string-width": "1.0.2",
-            "widest-line": "1.0.0"
+            "camelcase": "^2.1.0",
+            "chalk": "^1.1.1",
+            "cli-boxes": "^1.0.0",
+            "filled-array": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "repeating": "^2.0.0",
+            "string-width": "^1.0.1",
+            "widest-line": "^1.0.0"
           }
         },
         "ms": {
@@ -318,14 +318,14 @@
           "integrity": "sha1-FDxFMzg9CJCO9wVGIGOV/htauwY=",
           "dev": true,
           "requires": {
-            "ansi-align": "1.1.0",
-            "boxen": "0.5.1",
-            "chalk": "1.1.3",
-            "configstore": "2.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "2.0.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "2.0.0"
+            "ansi-align": "^1.0.0",
+            "boxen": "^0.5.1",
+            "chalk": "^1.0.0",
+            "configstore": "^2.0.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^2.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^2.0.0"
           }
         }
       }
@@ -336,12 +336,12 @@
       "integrity": "sha1-7xntCyS2vzWdrW+63xoF2DY5XJE=",
       "dev": true,
       "requires": {
-        "arr-exclude": "1.0.0",
-        "cross-spawn": "4.0.2",
-        "pinkie-promise": "2.0.1",
-        "read-pkg-up": "1.0.1",
-        "the-argv": "1.0.0",
-        "write-pkg": "1.0.0"
+        "arr-exclude": "^1.0.0",
+        "cross-spawn": "^4.0.0",
+        "pinkie-promise": "^2.0.0",
+        "read-pkg-up": "^1.0.1",
+        "the-argv": "^1.0.0",
+        "write-pkg": "^1.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -350,8 +350,8 @@
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.1",
-            "which": "1.2.14"
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
           }
         }
       }
@@ -374,9 +374,9 @@
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.1"
+        "chalk": "^1.1.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
       }
     },
     "babel-core": {
@@ -385,25 +385,25 @@
       "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-generator": "6.25.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.3",
-        "convert-source-map": "1.5.0",
-        "debug": "2.6.8",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
-        "slash": "1.0.0",
-        "source-map": "0.5.6"
+        "babel-code-frame": "^6.22.0",
+        "babel-generator": "^6.25.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.25.0",
+        "babel-traverse": "^6.25.0",
+        "babel-types": "^6.25.0",
+        "babylon": "^6.17.2",
+        "convert-source-map": "^1.1.0",
+        "debug": "^2.1.1",
+        "json5": "^0.5.0",
+        "lodash": "^4.2.0",
+        "minimatch": "^3.0.2",
+        "path-is-absolute": "^1.0.0",
+        "private": "^0.1.6",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "lodash": {
@@ -426,14 +426,14 @@
       "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.6",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.25.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.2.0",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "lodash": {
@@ -456,9 +456,9 @@
       "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -467,9 +467,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -478,10 +478,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -490,10 +490,10 @@
       "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1",
+        "lodash": "^4.2.0"
       },
       "dependencies": {
         "lodash": {
@@ -510,9 +510,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-explode-class": {
@@ -521,10 +521,10 @@
       "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
       "dev": true,
       "requires": {
-        "babel-helper-bindify-decorators": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-helper-bindify-decorators": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -533,11 +533,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -546,8 +546,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -556,8 +556,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -566,8 +566,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -576,9 +576,9 @@
       "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1",
+        "lodash": "^4.2.0"
       },
       "dependencies": {
         "lodash": {
@@ -595,11 +595,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -608,12 +608,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -622,8 +622,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-messages": {
@@ -632,7 +632,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-ava-throws-helper": {
@@ -641,8 +641,8 @@
       "integrity": "sha1-mC0djiRP1L0zYV2nVEFMx7Cocwo=",
       "dev": true,
       "requires": {
-        "babel-template": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-template": "^6.7.0",
+        "babel-types": "^6.7.2"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -651,7 +651,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-detective": {
@@ -666,13 +666,13 @@
       "integrity": "sha1-VRa4/NsmyfDh2BYHSfbkxl5xJx4=",
       "dev": true,
       "requires": {
-        "babel-generator": "6.25.0",
-        "babylon": "6.17.3",
-        "call-matcher": "1.0.1",
-        "core-js": "2.4.1",
-        "espower-location-detector": "1.0.0",
-        "espurify": "1.7.0",
-        "estraverse": "4.2.0"
+        "babel-generator": "^6.1.0",
+        "babylon": "^6.1.0",
+        "call-matcher": "^1.0.0",
+        "core-js": "^2.0.0",
+        "espower-location-detector": "^1.0.0",
+        "espurify": "^1.6.0",
+        "estraverse": "^4.1.1"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -729,9 +729,9 @@
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-generators": "6.13.0",
-        "babel-runtime": "6.23.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-generators": "^6.5.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-async-to-generator": {
@@ -740,9 +740,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.23.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -751,10 +751,10 @@
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-decorators": {
@@ -763,11 +763,11 @@
       "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-class": "6.24.1",
-        "babel-plugin-syntax-decorators": "6.13.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-helper-explode-class": "^6.24.1",
+        "babel-plugin-syntax-decorators": "^6.13.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -776,7 +776,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -785,7 +785,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -794,11 +794,11 @@
       "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1",
+        "lodash": "^4.2.0"
       },
       "dependencies": {
         "lodash": {
@@ -815,15 +815,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.24.1",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -832,8 +832,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -842,7 +842,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -851,8 +851,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -861,7 +861,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -870,9 +870,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -881,7 +881,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -890,9 +890,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -901,10 +901,10 @@
       "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -913,9 +913,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -924,9 +924,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -935,8 +935,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.23.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -945,12 +945,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -959,8 +959,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -969,7 +969,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -978,9 +978,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -989,7 +989,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -998,7 +998,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1007,9 +1007,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1018,9 +1018,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.23.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -1029,8 +1029,8 @@
       "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.23.0"
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1048,7 +1048,7 @@
       "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1057,8 +1057,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-preset-es2015": {
@@ -1067,30 +1067,30 @@
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.24.1"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.24.1",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+        "babel-plugin-transform-es2015-object-super": "^6.24.1",
+        "babel-plugin-transform-es2015-parameters": "^6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+        "babel-plugin-transform-regenerator": "^6.24.1"
       }
     },
     "babel-preset-stage-2": {
@@ -1099,10 +1099,10 @@
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-decorators": "6.24.1",
-        "babel-preset-stage-3": "6.24.1"
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-decorators": "^6.24.1",
+        "babel-preset-stage-3": "^6.24.1"
       }
     },
     "babel-preset-stage-3": {
@@ -1111,11 +1111,11 @@
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-generator-functions": "6.24.1",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-object-rest-spread": "6.23.0"
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-generator-functions": "^6.24.1",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+        "babel-plugin-transform-object-rest-spread": "^6.22.0"
       }
     },
     "babel-register": {
@@ -1124,13 +1124,13 @@
       "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
       "dev": true,
       "requires": {
-        "babel-core": "6.25.0",
-        "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.15"
+        "babel-core": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "core-js": "^2.4.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.2"
       },
       "dependencies": {
         "lodash": {
@@ -1147,8 +1147,8 @@
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
-        "regenerator-runtime": "0.10.5"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.10.0"
       }
     },
     "babel-template": {
@@ -1157,11 +1157,11 @@
       "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.3",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.25.0",
+        "babel-types": "^6.25.0",
+        "babylon": "^6.17.2",
+        "lodash": "^4.2.0"
       },
       "dependencies": {
         "lodash": {
@@ -1178,15 +1178,15 @@
       "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.3",
-        "debug": "2.6.8",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "babel-code-frame": "^6.22.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.25.0",
+        "babylon": "^6.17.2",
+        "debug": "^2.2.0",
+        "globals": "^9.0.0",
+        "invariant": "^2.2.0",
+        "lodash": "^4.2.0"
       },
       "dependencies": {
         "lodash": {
@@ -1203,10 +1203,10 @@
       "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.22.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.2.0",
+        "to-fast-properties": "^1.0.1"
       },
       "dependencies": {
         "lodash": {
@@ -1235,7 +1235,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "beeper": {
@@ -1265,7 +1265,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "bluebird": {
@@ -1279,15 +1279,15 @@
       "integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
       "requires": {
         "bytes": "2.2.0",
-        "content-type": "1.0.2",
-        "debug": "2.2.0",
-        "depd": "1.1.0",
-        "http-errors": "1.3.1",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.3.1",
         "iconv-lite": "0.4.13",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "5.2.0",
-        "raw-body": "2.1.7",
-        "type-is": "1.6.15"
+        "raw-body": "~2.1.5",
+        "type-is": "~1.6.10"
       },
       "dependencies": {
         "debug": {
@@ -1316,7 +1316,7 @@
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "bourbon": {
@@ -1329,15 +1329,15 @@
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
       "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
       "requires": {
-        "ansi-align": "1.1.0",
-        "camelcase": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-boxes": "1.0.0",
-        "filled-array": "1.1.0",
-        "object-assign": "4.1.1",
-        "repeating": "2.0.1",
-        "string-width": "1.0.2",
-        "widest-line": "1.0.0"
+        "ansi-align": "^1.1.0",
+        "camelcase": "^2.1.0",
+        "chalk": "^1.1.1",
+        "cli-boxes": "^1.0.0",
+        "filled-array": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "repeating": "^2.0.0",
+        "string-width": "^1.0.1",
+        "widest-line": "^1.0.0"
       },
       "dependencies": {
         "object-assign": {
@@ -1352,7 +1352,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1361,9 +1361,9 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "buf-compare": {
@@ -1399,9 +1399,9 @@
       "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
       "dev": true,
       "requires": {
-        "md5-hex": "1.3.0",
-        "mkdirp": "0.5.1",
-        "write-file-atomic": "1.3.4"
+        "md5-hex": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "write-file-atomic": "^1.1.4"
       }
     },
     "call-matcher": {
@@ -1410,10 +1410,10 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
-        "deep-equal": "1.0.1",
-        "espurify": "1.7.0",
-        "estraverse": "4.2.0"
+        "core-js": "^2.0.0",
+        "deep-equal": "^1.0.0",
+        "espurify": "^1.6.0",
+        "estraverse": "^4.0.0"
       }
     },
     "call-signature": {
@@ -1432,8 +1432,8 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "capture-stack-trace": {
@@ -1471,11 +1471,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "chokidar": {
@@ -1485,15 +1485,15 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "anymatch": "1.3.0",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.1",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "ci-info": {
@@ -1513,7 +1513,7 @@
       "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.5.tgz",
       "integrity": "sha1-ePlIXNFhtWbppsctcXDEJw6B22E=",
       "requires": {
-        "glob": "7.1.2"
+        "glob": ">= 3.1.4"
       }
     },
     "cli-boxes": {
@@ -1526,8 +1526,8 @@
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
       "integrity": "sha1-CiXOrlpqFgK+f3fShWPDZwAnTog=",
       "requires": {
-        "es5-ext": "0.9.2",
-        "memoizee": "0.2.6"
+        "es5-ext": "~0.9.2",
+        "memoizee": "~0.2.5"
       }
     },
     "cli-color-keywords": {
@@ -1535,8 +1535,8 @@
       "resolved": "https://registry.npmjs.org/cli-color-keywords/-/cli-color-keywords-0.0.1.tgz",
       "integrity": "sha1-3eoJX653nJ5LT0FYHsenbbSOlLc=",
       "requires": {
-        "chalk": "1.1.3",
-        "lodash": "3.10.1"
+        "chalk": "^1.0.0",
+        "lodash": "^3.10.1"
       }
     },
     "cli-cursor": {
@@ -1544,7 +1544,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-spinners": {
@@ -1560,7 +1560,7 @@
       "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       }
     },
     "cli-width": {
@@ -1574,9 +1574,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "clone": {
@@ -1599,9 +1599,9 @@
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
       "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
       "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "1.0.7",
-        "through2": "2.0.3"
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^1.0.6",
+        "through2": "^2.0.1"
       }
     },
     "co": {
@@ -1616,7 +1616,7 @@
       "integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "1.0.0"
+        "pinkie-promise": "^1.0.0"
       },
       "dependencies": {
         "pinkie": {
@@ -1631,7 +1631,7 @@
           "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
           "dev": true,
           "requires": {
-            "pinkie": "1.0.0"
+            "pinkie": "^1.0.0"
           }
         }
       }
@@ -1652,7 +1652,7 @@
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "common-path-prefix": {
@@ -1682,9 +1682,9 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.2.11",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "concat-with-sourcemaps": {
@@ -1692,7 +1692,7 @@
       "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
       "integrity": "sha1-9Vs74q60dgGxCi1SWcz7cP0vHdY=",
       "requires": {
-        "source-map": "0.5.6"
+        "source-map": "^0.5.1"
       },
       "dependencies": {
         "source-map": {
@@ -1707,15 +1707,15 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
       "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
       "requires": {
-        "dot-prop": "3.0.0",
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "os-tmpdir": "1.0.2",
-        "osenv": "0.1.4",
-        "uuid": "2.0.3",
-        "write-file-atomic": "1.3.4",
-        "xdg-basedir": "2.0.0"
+        "dot-prop": "^3.0.0",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "object-assign": "^4.0.1",
+        "os-tmpdir": "^1.0.0",
+        "osenv": "^0.1.0",
+        "uuid": "^2.0.1",
+        "write-file-atomic": "^1.1.2",
+        "xdg-basedir": "^2.0.0"
       },
       "dependencies": {
         "object-assign": {
@@ -1736,8 +1736,8 @@
       "resolved": "https://registry.npmjs.org/content-formatter/-/content-formatter-1.1.0.tgz",
       "integrity": "sha1-N4/I4IDGF/pAvN/GwdiMNJ40wfo=",
       "requires": {
-        "drip": "1.4.0",
-        "lodash": "3.10.1",
+        "drip": "^1.4.0",
+        "lodash": "^3.10.0",
         "string-sub": "0.0.1"
       }
     },
@@ -1747,8 +1747,8 @@
       "integrity": "sha1-6s1fuI8e4tT5BFNYfqaOIaf0n9I=",
       "requires": {
         "content-logger-handlebars-helpers": "0.0.1",
-        "drip": "1.4.0",
-        "lodash": "3.10.1"
+        "drip": "^1.4.0",
+        "lodash": "^3.10.1"
       }
     },
     "content-logger-handlebars-helpers": {
@@ -1757,8 +1757,8 @@
       "integrity": "sha1-V797IGgUio4PZItp+SnF0qUNQr0=",
       "requires": {
         "cli-color-keywords": "0.0.1",
-        "handlebars": "3.0.3",
-        "lodash": "3.10.1"
+        "handlebars": "^3.0.3",
+        "lodash": "^3.10.1"
       }
     },
     "content-type": {
@@ -1771,17 +1771,17 @@
       "resolved": "https://registry.npmjs.org/convert-bootstrap-2-to-3/-/convert-bootstrap-2-to-3-1.0.3.tgz",
       "integrity": "sha1-dn6Z5pGLLgOr2SawCe8+ckHSnts=",
       "requires": {
-        "async": "0.7.0",
-        "cli": "0.4.5",
+        "async": "^0.7.0",
+        "cli": "^0.4.5",
         "cli-color-keywords": "0.0.1",
-        "content-formatter": "1.1.0",
+        "content-formatter": "^1.1.0",
         "content-logger": "0.0.3",
-        "diff": "1.4.0",
-        "lodash": "3.10.1",
-        "optimist": "0.6.1",
-        "roolz": "1.0.2",
+        "diff": "^1.0.8",
+        "lodash": "^3.10.1",
+        "optimist": "^0.6.1",
+        "roolz": "^1.0.2",
         "string-sub": "0.0.1",
-        "to-int": "0.1.0"
+        "to-int": "^0.1.0"
       },
       "dependencies": {
         "async": {
@@ -1802,8 +1802,8 @@
       "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
       "dev": true,
       "requires": {
-        "buf-compare": "1.0.1",
-        "is-error": "2.2.1"
+        "buf-compare": "^1.0.0",
+        "is-error": "^2.2.0"
       }
     },
     "core-js": {
@@ -1822,7 +1822,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -1830,8 +1830,8 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.2.3.tgz",
       "integrity": "sha1-+sViAt/T0N2GF3jy2iA79DS7ghw=",
       "requires": {
-        "cross-spawn-async": "2.2.5",
-        "spawn-sync": "1.0.15"
+        "cross-spawn-async": "^2.2.2",
+        "spawn-sync": "^1.0.15"
       }
     },
     "cross-spawn-async": {
@@ -1839,8 +1839,8 @@
       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
       "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
       "requires": {
-        "lru-cache": "4.1.1",
-        "which": "1.2.14"
+        "lru-cache": "^4.0.0",
+        "which": "^1.2.8"
       }
     },
     "cryptiles": {
@@ -1849,7 +1849,7 @@
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1"
+        "boom": "2.x.x"
       }
     },
     "cson-parser": {
@@ -1857,7 +1857,7 @@
       "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
       "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
       "requires": {
-        "coffee-script": "1.12.6"
+        "coffee-script": "^1.10.0"
       }
     },
     "css-stringify": {
@@ -1865,7 +1865,7 @@
       "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.4.1.tgz",
       "integrity": "sha1-JSzL8D9yOgCb3Ydw/n6ydBca/fo=",
       "requires": {
-        "source-map": "0.1.43"
+        "source-map": "~0.1.31"
       }
     },
     "currently-unhandled": {
@@ -1873,7 +1873,7 @@
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "dargs": {
@@ -1888,7 +1888,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -1923,6 +1923,14 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "deep-eql": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
@@ -1948,7 +1956,7 @@
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "requires": {
-        "clone": "1.0.2"
+        "clone": "^1.0.2"
       }
     },
     "del": {
@@ -1956,12 +1964,12 @@
       "resolved": "https://registry.npmjs.org/del/-/del-1.2.1.tgz",
       "integrity": "sha1-rtblvNfLcyXfNPVjEl+iZbLBoBQ=",
       "requires": {
-        "each-async": "1.1.1",
-        "globby": "2.1.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "3.0.0",
-        "rimraf": "2.6.1"
+        "each-async": "^1.0.0",
+        "globby": "^2.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^3.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "async": {
@@ -1974,11 +1982,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globby": {
@@ -1986,10 +1994,10 @@
           "resolved": "https://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
           "integrity": "sha1-npGSvNM/Srak+JTl5+qLcTITxII=",
           "requires": {
-            "array-union": "1.0.2",
-            "async": "1.5.2",
-            "glob": "5.0.15",
-            "object-assign": "3.0.0"
+            "array-union": "^1.0.1",
+            "async": "^1.2.1",
+            "glob": "^5.0.3",
+            "object-assign": "^3.0.0"
           }
         }
       }
@@ -2021,7 +2029,7 @@
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
       "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
       "requires": {
-        "fs-exists-sync": "0.1.0"
+        "fs-exists-sync": "^0.1.0"
       }
     },
     "detect-indent": {
@@ -2030,7 +2038,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "diff": {
@@ -2049,7 +2057,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "drip": {
@@ -2070,7 +2078,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.9"
       },
       "dependencies": {
         "isarray": {
@@ -2083,10 +2091,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -2096,15 +2104,20 @@
         }
       }
     },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+    },
     "duplexify": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
       "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
       "requires": {
         "end-of-stream": "1.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.2.11",
-        "stream-shift": "1.0.0"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       },
       "dependencies": {
         "end-of-stream": {
@@ -2112,7 +2125,7 @@
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
           "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
           "requires": {
-            "once": "1.3.3"
+            "once": "~1.3.0"
           }
         },
         "once": {
@@ -2120,7 +2133,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         }
       }
@@ -2130,8 +2143,8 @@
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "requires": {
-        "onetime": "1.1.0",
-        "set-immediate-shim": "1.0.1"
+        "onetime": "^1.0.0",
+        "set-immediate-shim": "^1.0.0"
       }
     },
     "eastasianwidth": {
@@ -2147,7 +2160,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ee-first": {
@@ -2162,8 +2175,8 @@
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "1.2.7",
-        "xtend": "4.0.1"
+        "core-js": "^1.2.6",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "core-js": {
@@ -2179,7 +2192,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
       "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
       "requires": {
-        "once": "1.3.3"
+        "once": "~1.3.0"
       },
       "dependencies": {
         "once": {
@@ -2187,7 +2200,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         }
       }
@@ -2197,7 +2210,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es5-ext": {
@@ -2216,10 +2229,10 @@
       "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
       "dev": true,
       "requires": {
-        "is-url": "1.2.2",
-        "path-is-absolute": "1.0.1",
-        "source-map": "0.5.6",
-        "xtend": "4.0.1"
+        "is-url": "^1.2.1",
+        "path-is-absolute": "^1.0.0",
+        "source-map": "^0.5.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "source-map": {
@@ -2241,7 +2254,7 @@
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1"
+        "core-js": "^2.0.0"
       }
     },
     "estraverse": {
@@ -2261,7 +2274,7 @@
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
       "integrity": "sha1-yB43JOtVQHxaDV7jKZQR9wD1QpE=",
       "requires": {
-        "es5-ext": "0.9.2"
+        "es5-ext": "~0.9.2"
       }
     },
     "event-stream": {
@@ -2269,13 +2282,13 @@
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.1.0",
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
       }
     },
     "exit-hook": {
@@ -2288,7 +2301,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -2296,7 +2309,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "expand-tilde": {
@@ -2304,7 +2317,7 @@
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.1"
       }
     },
     "extend": {
@@ -2317,7 +2330,7 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extsprintf": {
@@ -2331,8 +2344,8 @@
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
       "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
       "requires": {
-        "chalk": "1.1.3",
-        "time-stamp": "1.1.0"
+        "chalk": "^1.1.1",
+        "time-stamp": "^1.0.0"
       }
     },
     "faye-websocket": {
@@ -2340,7 +2353,7 @@
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
       "integrity": "sha1-zEB0x/Sk39A69U3WXDVLE1EyzhE=",
       "requires": {
-        "websocket-driver": "0.6.5"
+        "websocket-driver": ">=0.3.6"
       }
     },
     "figures": {
@@ -2348,8 +2361,8 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       },
       "dependencies": {
         "object-assign": {
@@ -2369,11 +2382,11 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "filled-array": {
@@ -2387,9 +2400,9 @@
       "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
       "dev": true,
       "requires": {
-        "commondir": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pkg-dir": "1.0.0"
+        "commondir": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pkg-dir": "^1.0.0"
       }
     },
     "find-index": {
@@ -2402,8 +2415,8 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "findup-sync": {
@@ -2411,7 +2424,7 @@
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
       "integrity": "sha1-4KkKRQB1xJRm7lE3MgV1FLgeh4w=",
       "requires": {
-        "glob": "4.3.5"
+        "glob": "~4.3.0"
       },
       "dependencies": {
         "glob": {
@@ -2419,10 +2432,10 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
           "integrity": "sha1-gPuwjKVA8jiszl0R0em8QedRc9M=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^2.0.1",
+            "once": "^1.3.0"
           }
         },
         "minimatch": {
@@ -2430,7 +2443,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.0.0"
           }
         }
       }
@@ -2440,13 +2453,13 @@
       "resolved": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
       "integrity": "sha1-WyhCS3YNdZiWC374SA3/itNmDpc=",
       "requires": {
-        "expand-tilde": "1.2.2",
-        "lodash.assignwith": "4.2.0",
-        "lodash.isempty": "4.4.0",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.isstring": "4.0.1",
-        "lodash.pick": "4.4.0",
-        "parse-filepath": "1.0.1"
+        "expand-tilde": "^1.2.1",
+        "lodash.assignwith": "^4.0.7",
+        "lodash.isempty": "^4.2.1",
+        "lodash.isplainobject": "^4.0.4",
+        "lodash.isstring": "^4.0.1",
+        "lodash.pick": "^4.2.1",
+        "parse-filepath": "^1.0.1"
       }
     },
     "first-chunk-stream": {
@@ -2475,7 +2488,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "forever-agent": {
@@ -2495,9 +2508,9 @@
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.15"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "formatio": {
@@ -2506,7 +2519,7 @@
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "1.1.2"
+        "samsam": "~1.1"
       }
     },
     "from": {
@@ -2524,10 +2537,10 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.24.0.tgz",
       "integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "fs.realpath": {
@@ -2536,18 +2549,18 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.1.tgz",
-      "integrity": "sha1-8Z/Sj0Pur3YWgOUZogPE0LPTGv8=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.6.2",
-        "node-pre-gyp": "0.6.33"
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
       },
       "dependencies": {
         "abbrev": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2557,142 +2570,46 @@
           "bundled": true,
           "dev": true
         },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
         "aproba": {
-          "version": "1.1.1",
+          "version": "1.2.0",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.2",
+          "version": "1.1.4",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.2"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
-        "caseless": {
-          "version": "0.11.0",
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
           "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -2707,53 +2624,23 @@
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.1",
-          "bundled": true,
           "dev": true,
           "optional": true
         },
-        "delayed-stream": {
-          "version": "1.0.0",
+        "debug": {
+          "version": "2.6.9",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -2761,167 +2648,55 @@
           "dev": true,
           "optional": true
         },
-        "ecc-jsbn": {
-          "version": "0.1.1",
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extend": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.14"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.10",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.5.4"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.10",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.3"
-          }
-        },
-        "gauge": {
-          "version": "2.7.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.0"
-          }
-        },
-        "generate-function": {
-          "version": "2.0.0",
-          "bundled": true,
           "dev": true,
           "optional": true
         },
-        "generate-object-property": {
-          "version": "1.2.0",
+        "gauge": {
+          "version": "2.7.4",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "is-property": "1.0.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
-          "version": "7.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.3",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "2.0.6",
+          "version": "7.1.2",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.9.0",
-            "is-my-json-valid": "2.15.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -2930,41 +2705,32 @@
           "dev": true,
           "optional": true
         },
-        "hawk": {
-          "version": "3.1.3",
+        "iconv-lite": {
+          "version": "0.4.21",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "safer-buffer": "^2.1.0"
           }
         },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
+        "ignore-walk": {
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.3.1",
-            "sshpk": "1.10.2"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -2973,7 +2739,7 @@
           "dev": true
         },
         "ini": {
-          "version": "1.3.4",
+          "version": "1.3.5",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2983,113 +2749,45 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
-        },
-        "is-my-json-valid": {
-          "version": "2.15.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "generate-function": "2.0.0",
-            "generate-object-property": "1.2.0",
-            "jsonpointer": "4.0.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
           "dev": true,
           "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonpointer": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          }
-        },
-        "mime-db": {
-          "version": "1.26.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.14",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.26.0"
-          }
         },
         "minimatch": {
-          "version": "3.0.3",
+          "version": "3.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.6"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
           "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
         },
         "mkdirp": {
           "version": "0.5.1",
@@ -3100,59 +2798,89 @@
           }
         },
         "ms": {
-          "version": "0.7.1",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "optional": true
         },
-        "node-pre-gyp": {
-          "version": "0.6.33",
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "4.0.2",
-            "rc": "1.1.7",
-            "request": "2.79.0",
-            "rimraf": "2.5.4",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.3.0"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
-          "version": "3.0.6",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
-          "version": "4.0.2",
+          "version": "4.1.2",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.2",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.3",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
           "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3165,56 +2893,53 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "bundled": true,
           "dev": true,
           "optional": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
         },
         "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.3.1",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
-          "version": "1.1.7",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.1",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -3226,58 +2951,48 @@
           }
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.3.6",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.79.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.0",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.2",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.14",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.0.1"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
-          "version": "2.5.4",
+          "version": "2.6.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "glob": "7.1.1"
+            "glob": "^7.0.5"
           }
         },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
         "semver": {
-          "version": "5.3.0",
+          "version": "5.5.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3294,67 +3009,31 @@
           "dev": true,
           "optional": true
         },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.10.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.6",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "bundled": true,
-          "dev": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -3363,118 +3042,34 @@
           "dev": true,
           "optional": true
         },
-        "supports-color": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
         "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.10",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.3.0",
+          "version": "4.4.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.2.0",
-            "fstream": "1.0.10",
-            "fstream-ignore": "1.0.5",
-            "once": "1.3.3",
-            "readable-stream": "2.1.5",
-            "rimraf": "2.5.4",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          },
-          "dependencies": {
-            "once": {
-              "version": "1.3.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "readable-stream": {
-              "version": "2.1.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "buffer-shims": "1.0.0",
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.2"
-              }
-            }
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
           "dev": true,
           "optional": true
         },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
         "wide-align": {
-          "version": "1.1.0",
+          "version": "1.1.2",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -3482,11 +3077,10 @@
           "bundled": true,
           "dev": true
         },
-        "xtend": {
-          "version": "4.0.1",
+        "yallist": {
+          "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3496,10 +3090,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "gauge": {
@@ -3508,14 +3102,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.1.2",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       },
       "dependencies": {
         "object-assign": {
@@ -3531,7 +3125,7 @@
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
       "requires": {
-        "globule": "0.1.0"
+        "globule": "~0.1.0"
       }
     },
     "get-caller-file": {
@@ -3545,13 +3139,18 @@
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -3567,12 +3166,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -3580,8 +3179,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -3589,7 +3188,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "glob-stream": {
@@ -3597,12 +3196,12 @@
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "requires": {
-        "glob": "4.5.3",
-        "glob2base": "0.0.12",
-        "minimatch": "2.0.10",
-        "ordered-read-streams": "0.1.0",
-        "through2": "0.6.5",
-        "unique-stream": "1.0.0"
+        "glob": "^4.3.1",
+        "glob2base": "^0.0.12",
+        "minimatch": "^2.0.1",
+        "ordered-read-streams": "^0.1.0",
+        "through2": "^0.6.1",
+        "unique-stream": "^1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -3610,10 +3209,10 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^2.0.1",
+            "once": "^1.3.0"
           }
         },
         "isarray": {
@@ -3626,7 +3225,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.0.0"
           }
         },
         "readable-stream": {
@@ -3634,10 +3233,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3650,8 +3249,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -3661,7 +3260,7 @@
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
       "requires": {
-        "gaze": "0.5.2"
+        "gaze": "^0.5.1"
       }
     },
     "glob2base": {
@@ -3669,7 +3268,7 @@
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "requires": {
-        "find-index": "0.1.1"
+        "find-index": "^0.1.1"
       }
     },
     "global-modules": {
@@ -3677,8 +3276,8 @@
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
       "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
+        "global-prefix": "^0.1.4",
+        "is-windows": "^0.2.0"
       }
     },
     "global-prefix": {
@@ -3686,10 +3285,10 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
       "requires": {
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.4",
-        "is-windows": "0.2.0",
-        "which": "1.2.14"
+        "homedir-polyfill": "^1.0.0",
+        "ini": "^1.3.4",
+        "is-windows": "^0.2.0",
+        "which": "^1.2.12"
       }
     },
     "globals": {
@@ -3703,12 +3302,12 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
       "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "6.0.4",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^6.0.1",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "glob": {
@@ -3716,11 +3315,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "object-assign": {
@@ -3735,9 +3334,9 @@
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "requires": {
-        "glob": "3.1.21",
-        "lodash": "1.0.2",
-        "minimatch": "0.2.14"
+        "glob": "~3.1.21",
+        "lodash": "~1.0.1",
+        "minimatch": "~0.2.11"
       },
       "dependencies": {
         "glob": {
@@ -3745,9 +3344,9 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
+            "graceful-fs": "~1.2.0",
+            "inherits": "1",
+            "minimatch": "~0.2.11"
           }
         },
         "graceful-fs": {
@@ -3775,8 +3374,8 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -3786,7 +3385,7 @@
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
       "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
       "requires": {
-        "sparkles": "1.0.0"
+        "sparkles": "^1.0.0"
       }
     },
     "gogo-shell": {
@@ -3794,8 +3393,8 @@
       "resolved": "https://registry.npmjs.org/gogo-shell/-/gogo-shell-0.0.5.tgz",
       "integrity": "sha1-o3U5wDvym29jfbvK+aTTRPAWZwc=",
       "requires": {
-        "bluebird": "3.5.0",
-        "lodash": "4.17.4"
+        "bluebird": "^3.3.3",
+        "lodash": "^4.6.1"
       },
       "dependencies": {
         "lodash": {
@@ -3811,7 +3410,7 @@
       "integrity": "sha1-zxAH5+/bzB000fSqR9qjh1Ly3U0=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.7.0"
       },
       "dependencies": {
         "lodash": {
@@ -3827,21 +3426,21 @@
       "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
       "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
       "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer2": "0.1.4",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "node-status-codes": "1.0.0",
-        "object-assign": "4.1.1",
-        "parse-json": "2.2.0",
-        "pinkie-promise": "2.0.1",
-        "read-all-stream": "3.1.0",
-        "readable-stream": "2.2.11",
-        "timed-out": "3.1.3",
-        "unzip-response": "1.0.2",
-        "url-parse-lax": "1.0.0"
+        "create-error-class": "^3.0.1",
+        "duplexer2": "^0.1.4",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "node-status-codes": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "parse-json": "^2.1.0",
+        "pinkie-promise": "^2.0.0",
+        "read-all-stream": "^3.0.0",
+        "readable-stream": "^2.0.5",
+        "timed-out": "^3.0.0",
+        "unzip-response": "^1.0.2",
+        "url-parse-lax": "^1.0.0"
       },
       "dependencies": {
         "duplexer2": {
@@ -3849,7 +3448,7 @@
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "requires": {
-            "readable-stream": "2.2.11"
+            "readable-stream": "^2.0.2"
           }
         },
         "object-assign": {
@@ -3869,19 +3468,19 @@
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "requires": {
-        "archy": "1.0.0",
-        "chalk": "1.1.3",
-        "deprecated": "0.0.1",
-        "gulp-util": "3.0.8",
-        "interpret": "1.0.3",
-        "liftoff": "2.3.0",
-        "minimist": "1.2.0",
-        "orchestrator": "0.3.8",
-        "pretty-hrtime": "1.0.3",
-        "semver": "4.3.6",
-        "tildify": "1.2.0",
-        "v8flags": "2.1.1",
-        "vinyl-fs": "0.3.14"
+        "archy": "^1.0.0",
+        "chalk": "^1.0.0",
+        "deprecated": "^0.0.1",
+        "gulp-util": "^3.0.0",
+        "interpret": "^1.0.0",
+        "liftoff": "^2.1.0",
+        "minimist": "^1.1.0",
+        "orchestrator": "^0.3.0",
+        "pretty-hrtime": "^1.0.0",
+        "semver": "^4.1.0",
+        "tildify": "^1.0.0",
+        "v8flags": "^2.0.2",
+        "vinyl-fs": "^0.3.0"
       }
     },
     "gulp-concat": {
@@ -3889,9 +3488,9 @@
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
       "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
       "requires": {
-        "concat-with-sourcemaps": "1.0.4",
-        "through2": "2.0.3",
-        "vinyl": "2.0.2"
+        "concat-with-sourcemaps": "^1.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^2.0.0"
       }
     },
     "gulp-debug": {
@@ -3899,13 +3498,13 @@
       "resolved": "https://registry.npmjs.org/gulp-debug/-/gulp-debug-2.1.2.tgz",
       "integrity": "sha1-L1/l9kvNH0zxicFg4IDIrQZUMJQ=",
       "requires": {
-        "chalk": "1.1.3",
-        "gulp-util": "3.0.8",
-        "object-assign": "4.1.1",
-        "plur": "2.1.2",
-        "stringify-object": "2.4.0",
-        "through2": "2.0.3",
-        "tildify": "1.2.0"
+        "chalk": "^1.0.0",
+        "gulp-util": "^3.0.0",
+        "object-assign": "^4.0.1",
+        "plur": "^2.0.0",
+        "stringify-object": "^2.3.0",
+        "through2": "^2.0.0",
+        "tildify": "^1.1.2"
       },
       "dependencies": {
         "object-assign": {
@@ -3920,11 +3519,11 @@
       "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-2.0.2.tgz",
       "integrity": "sha1-HOsdET7plCzt1J9YY7Qr5EvHzSw=",
       "requires": {
-        "gulp-util": "3.0.8",
-        "merge-stream": "0.1.8",
-        "multimatch": "2.1.0",
+        "gulp-util": "^3.0.0",
+        "merge-stream": "^0.1.7",
+        "multimatch": "^2.0.0",
         "plexer": "0.0.3",
-        "through2": "0.6.5"
+        "through2": "^0.6.1"
       },
       "dependencies": {
         "isarray": {
@@ -3937,10 +3536,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3953,8 +3552,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -3964,8 +3563,8 @@
       "resolved": "https://registry.npmjs.org/gulp-help/-/gulp-help-1.6.1.tgz",
       "integrity": "sha1-Jh2xhuGDl/7z9qLCLpwxW/qIrgw=",
       "requires": {
-        "chalk": "1.1.3",
-        "object-assign": "3.0.0"
+        "chalk": "^1.0.0",
+        "object-assign": "^3.0.0"
       }
     },
     "gulp-if": {
@@ -3973,9 +3572,9 @@
       "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
       "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
       "requires": {
-        "gulp-match": "1.0.3",
-        "ternary-stream": "2.0.1",
-        "through2": "2.0.3"
+        "gulp-match": "^1.0.3",
+        "ternary-stream": "^2.0.1",
+        "through2": "^2.0.1"
       }
     },
     "gulp-inject": {
@@ -3983,8 +3582,8 @@
       "resolved": "https://registry.npmjs.org/gulp-inject/-/gulp-inject-2.2.0.tgz",
       "integrity": "sha1-QN/REAW69rkYHvp3awf9S1JJZJY=",
       "requires": {
-        "event-stream": "3.3.4",
-        "gulp-util": "3.0.8"
+        "event-stream": "^3.1.0",
+        "gulp-util": "^3.0.0"
       }
     },
     "gulp-liferay-r2-css": {
@@ -3992,9 +3591,9 @@
       "resolved": "https://registry.npmjs.org/gulp-liferay-r2-css/-/gulp-liferay-r2-css-0.0.2.tgz",
       "integrity": "sha1-HSVfV/uu6j0wAtXX6Qvq2lEk32c=",
       "requires": {
-        "gulp-util": "3.0.8",
-        "liferay-r2": "0.4.4",
-        "through2": "2.0.3"
+        "gulp-util": "^3.0.7",
+        "liferay-r2": "^0.4.2",
+        "through2": "^2.0.0"
       }
     },
     "gulp-livereload": {
@@ -4002,12 +3601,12 @@
       "resolved": "https://registry.npmjs.org/gulp-livereload/-/gulp-livereload-3.8.1.tgz",
       "integrity": "sha1-APdEstdJ0+njdGWJyKRKysd5tQ8=",
       "requires": {
-        "chalk": "0.5.1",
-        "debug": "2.6.8",
-        "event-stream": "3.3.4",
-        "gulp-util": "3.0.8",
-        "lodash.assign": "3.2.0",
-        "mini-lr": "0.1.9"
+        "chalk": "^0.5.1",
+        "debug": "^2.1.0",
+        "event-stream": "^3.1.7",
+        "gulp-util": "^3.0.2",
+        "lodash.assign": "^3.0.0",
+        "mini-lr": "^0.1.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4025,11 +3624,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
           }
         },
         "has-ansi": {
@@ -4037,7 +3636,7 @@
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.0"
           }
         },
         "strip-ansi": {
@@ -4045,7 +3644,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.1"
           }
         },
         "supports-color": {
@@ -4060,7 +3659,7 @@
       "resolved": "https://registry.npmjs.org/gulp-load-plugins/-/gulp-load-plugins-0.8.1.tgz",
       "integrity": "sha1-CoJh0Fnf3ckY/aQGyCMucvo00uo=",
       "requires": {
-        "findup-sync": "0.2.1",
+        "findup-sync": "^0.2.1",
         "multimatch": "2.0.0"
       },
       "dependencies": {
@@ -4069,7 +3668,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.0.0"
           }
         },
         "multimatch": {
@@ -4077,9 +3676,9 @@
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
           "integrity": "sha1-xa2kJTV7dEulSELr3OHI8L5UK28=",
           "requires": {
-            "array-differ": "1.0.0",
-            "array-union": "1.0.2",
-            "minimatch": "2.0.10"
+            "array-differ": "^1.0.0",
+            "array-union": "^1.0.1",
+            "minimatch": "^2.0.1"
           }
         }
       }
@@ -4089,7 +3688,7 @@
       "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
       "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.3"
       }
     },
     "gulp-plumber": {
@@ -4097,8 +3696,8 @@
       "resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-0.6.6.tgz",
       "integrity": "sha1-n5hGpRPHDQMhbOeiqM5v1aP8MXU=",
       "requires": {
-        "gulp-util": "3.0.8",
-        "through2": "0.6.5"
+        "gulp-util": "~3",
+        "through2": "~0.6"
       },
       "dependencies": {
         "isarray": {
@@ -4111,10 +3710,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -4127,8 +3726,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -4138,8 +3737,8 @@
       "resolved": "https://registry.npmjs.org/gulp-prompt/-/gulp-prompt-0.1.2.tgz",
       "integrity": "sha1-BsmZvedk4++sYCJTbMK7Aiq4N1A=",
       "requires": {
-        "event-stream": "3.0.20",
-        "inquirer": "0.3.5"
+        "event-stream": "~3.0.20",
+        "inquirer": "~0.3.5"
       },
       "dependencies": {
         "async": {
@@ -4152,13 +3751,13 @@
           "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.0.20.tgz",
           "integrity": "sha1-A4u7LqnqkDhbJvvBhU0LU58qvqM=",
           "requires": {
-            "duplexer": "0.1.1",
-            "from": "0.1.7",
-            "map-stream": "0.0.7",
+            "duplexer": "~0.1.1",
+            "from": "~0",
+            "map-stream": "~0.0.3",
             "pause-stream": "0.0.11",
-            "split": "0.2.10",
-            "stream-combiner": "0.0.4",
-            "through": "2.3.8"
+            "split": "0.2",
+            "stream-combiner": "~0.0.3",
+            "through": "~2.3.1"
           }
         },
         "inquirer": {
@@ -4166,9 +3765,9 @@
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.3.5.tgz",
           "integrity": "sha1-p4vgZKyavxaBR8Ahaakx2aSDqfY=",
           "requires": {
-            "async": "0.2.10",
-            "cli-color": "0.2.3",
-            "lodash": "1.2.1",
+            "async": "~0.2.8",
+            "cli-color": "~0.2.2",
+            "lodash": "~1.2.1",
             "mute-stream": "0.0.3"
           }
         },
@@ -4187,7 +3786,7 @@
           "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
           "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
           "requires": {
-            "through": "2.3.8"
+            "through": "2"
           }
         }
       }
@@ -4203,8 +3802,8 @@
       "integrity": "sha1-Qy8kJkrP7T0hBdSpRbBMiqh8CJk=",
       "requires": {
         "applause": "0.4.3",
-        "gulp-util": "3.0.8",
-        "through2": "2.0.3"
+        "gulp-util": "^3.0.0",
+        "through2": "^2.0.0"
       }
     },
     "gulp-ruby-sass": {
@@ -4213,19 +3812,19 @@
       "integrity": "sha1-6A9lCSEI7kr8tJNgiNxyUzaa3Kw=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.5.0",
-        "cross-spawn": "5.1.0",
-        "dargs": "2.1.0",
-        "each-async": "1.1.1",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
+        "convert-source-map": "^1.0.0",
+        "cross-spawn": "^5.0.0",
+        "dargs": "^2.0.3",
+        "each-async": "^1.0.0",
+        "escape-string-regexp": "^1.0.3",
+        "glob": "^7.0.3",
         "glob2base": "0.0.12",
-        "gulp-util": "3.0.8",
-        "md5-hex": "1.3.0",
-        "object-assign": "4.1.1",
-        "os-tmpdir": "1.0.2",
-        "path-exists": "2.1.0",
-        "rimraf": "2.6.1"
+        "gulp-util": "^3.0.4",
+        "md5-hex": "^1.0.2",
+        "object-assign": "^4.0.1",
+        "os-tmpdir": "^1.0.0",
+        "path-exists": "^2.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "cross-spawn": {
@@ -4234,9 +3833,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.2.14"
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "object-assign": {
@@ -4253,11 +3852,11 @@
       "integrity": "sha1-U9xLaKH13f5EJKtMJHZVJpqLdLc=",
       "dev": true,
       "requires": {
-        "gulp-util": "3.0.8",
-        "lodash.clonedeep": "4.5.0",
-        "node-sass": "4.5.3",
-        "through2": "2.0.3",
-        "vinyl-sourcemaps-apply": "0.2.1"
+        "gulp-util": "^3.0",
+        "lodash.clonedeep": "^4.3.2",
+        "node-sass": "^4.2.0",
+        "through2": "^2.0.0",
+        "vinyl-sourcemaps-apply": "^0.2.0"
       }
     },
     "gulp-sourcemaps": {
@@ -4265,11 +3864,11 @@
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "requires": {
-        "convert-source-map": "1.5.0",
-        "graceful-fs": "4.1.11",
-        "strip-bom": "2.0.0",
-        "through2": "2.0.3",
-        "vinyl": "1.2.0"
+        "convert-source-map": "^1.1.1",
+        "graceful-fs": "^4.1.2",
+        "strip-bom": "^2.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^1.0.0"
       },
       "dependencies": {
         "clone-stats": {
@@ -4287,8 +3886,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "1.0.2",
-            "clone-stats": "0.0.1",
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -4299,10 +3898,10 @@
       "resolved": "https://registry.npmjs.org/gulp-storage/-/gulp-storage-1.0.6.tgz",
       "integrity": "sha1-FmjuOaK8877vbStrfW1tM0X0Etc=",
       "requires": {
-        "gulp": "3.9.1",
-        "gulp-util": "2.2.20",
-        "lodash": "2.4.2",
-        "through2": "2.0.3"
+        "gulp": "^3.8.9",
+        "gulp-util": "^2.2.20",
+        "lodash": "^2.4.1",
+        "through2": "*"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4320,11 +3919,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
           }
         },
         "clone-stats": {
@@ -4337,8 +3936,8 @@
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
+            "get-stdin": "^4.0.1",
+            "meow": "^3.3.0"
           }
         },
         "gulp-util": {
@@ -4346,14 +3945,14 @@
           "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
           "requires": {
-            "chalk": "0.5.1",
-            "dateformat": "1.0.12",
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.template": "2.4.1",
-            "minimist": "0.2.0",
-            "multipipe": "0.1.2",
-            "through2": "0.5.1",
-            "vinyl": "0.2.3"
+            "chalk": "^0.5.0",
+            "dateformat": "^1.0.7-1.2.3",
+            "lodash._reinterpolate": "^2.4.1",
+            "lodash.template": "^2.4.1",
+            "minimist": "^0.2.0",
+            "multipipe": "^0.1.0",
+            "through2": "^0.5.0",
+            "vinyl": "^0.2.1"
           },
           "dependencies": {
             "through2": {
@@ -4361,8 +3960,8 @@
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "3.0.0"
+                "readable-stream": "~1.0.17",
+                "xtend": "~3.0.0"
               }
             }
           }
@@ -4372,7 +3971,7 @@
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.0"
           }
         },
         "isarray": {
@@ -4395,9 +3994,9 @@
           "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
           "requires": {
-            "lodash._escapehtmlchar": "2.4.1",
-            "lodash._reunescapedhtml": "2.4.1",
-            "lodash.keys": "2.4.1"
+            "lodash._escapehtmlchar": "~2.4.1",
+            "lodash._reunescapedhtml": "~2.4.1",
+            "lodash.keys": "~2.4.1"
           }
         },
         "lodash.keys": {
@@ -4405,9 +4004,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
           }
         },
         "lodash.template": {
@@ -4415,13 +4014,13 @@
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
           "requires": {
-            "lodash._escapestringchar": "2.4.1",
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.defaults": "2.4.1",
-            "lodash.escape": "2.4.1",
-            "lodash.keys": "2.4.1",
-            "lodash.templatesettings": "2.4.1",
-            "lodash.values": "2.4.1"
+            "lodash._escapestringchar": "~2.4.1",
+            "lodash._reinterpolate": "~2.4.1",
+            "lodash.defaults": "~2.4.1",
+            "lodash.escape": "~2.4.1",
+            "lodash.keys": "~2.4.1",
+            "lodash.templatesettings": "~2.4.1",
+            "lodash.values": "~2.4.1"
           }
         },
         "lodash.templatesettings": {
@@ -4429,8 +4028,8 @@
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
           "requires": {
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.escape": "2.4.1"
+            "lodash._reinterpolate": "~2.4.1",
+            "lodash.escape": "~2.4.1"
           }
         },
         "minimist": {
@@ -4443,10 +4042,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -4459,7 +4058,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.1"
           }
         },
         "supports-color": {
@@ -4472,7 +4071,7 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
           "requires": {
-            "clone-stats": "0.0.1"
+            "clone-stats": "~0.0.1"
           }
         },
         "xtend": {
@@ -4487,24 +4086,24 @@
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "requires": {
-        "array-differ": "1.0.0",
-        "array-uniq": "1.0.3",
-        "beeper": "1.1.1",
-        "chalk": "1.1.3",
-        "dateformat": "2.0.0",
-        "fancy-log": "1.3.0",
-        "gulplog": "1.0.0",
-        "has-gulplog": "0.1.0",
-        "lodash._reescape": "3.0.0",
-        "lodash._reevaluate": "3.0.0",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.template": "3.6.2",
-        "minimist": "1.2.0",
-        "multipipe": "0.1.2",
-        "object-assign": "3.0.0",
+        "array-differ": "^1.0.0",
+        "array-uniq": "^1.0.2",
+        "beeper": "^1.0.0",
+        "chalk": "^1.0.0",
+        "dateformat": "^2.0.0",
+        "fancy-log": "^1.1.0",
+        "gulplog": "^1.0.0",
+        "has-gulplog": "^0.1.0",
+        "lodash._reescape": "^3.0.0",
+        "lodash._reevaluate": "^3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.template": "^3.0.0",
+        "minimist": "^1.1.0",
+        "multipipe": "^0.1.2",
+        "object-assign": "^3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "2.0.3",
-        "vinyl": "0.5.3"
+        "through2": "^2.0.0",
+        "vinyl": "^0.5.0"
       },
       "dependencies": {
         "clone-stats": {
@@ -4522,8 +4121,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
           "requires": {
-            "clone": "1.0.2",
-            "clone-stats": "0.0.1",
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -4534,11 +4133,11 @@
       "resolved": "https://registry.npmjs.org/gulp-zip/-/gulp-zip-3.2.0.tgz",
       "integrity": "sha1-69GY2ubcLV9E2BRWnI7EIRipPvk=",
       "requires": {
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.0",
-        "gulp-util": "3.0.8",
-        "through2": "2.0.3",
-        "yazl": "2.4.2"
+        "chalk": "^1.0.0",
+        "concat-stream": "^1.4.7",
+        "gulp-util": "^3.0.0",
+        "through2": "^2.0.1",
+        "yazl": "^2.1.0"
       }
     },
     "gulplog": {
@@ -4546,7 +4145,7 @@
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "requires": {
-        "glogg": "1.0.0"
+        "glogg": "^1.0.0"
       }
     },
     "handlebars": {
@@ -4554,9 +4153,9 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
       "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
       "requires": {
-        "optimist": "0.6.1",
-        "source-map": "0.1.43",
-        "uglify-js": "2.3.6"
+        "optimist": "^0.6.1",
+        "source-map": "^0.1.40",
+        "uglify-js": "~2.3"
       }
     },
     "har-schema": {
@@ -4571,8 +4170,8 @@
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
+        "ajv": "^4.9.1",
+        "har-schema": "^1.0.5"
       }
     },
     "has-ansi": {
@@ -4580,7 +4179,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-color": {
@@ -4600,7 +4199,20 @@
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "requires": {
-        "sparkles": "1.0.0"
+        "sparkles": "^1.0.0"
+      }
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "requires": {
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "has-unicode": {
@@ -4615,10 +4227,10 @@
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "hoek": {
@@ -4633,8 +4245,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "homedir-polyfill": {
@@ -4642,7 +4254,7 @@
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -4655,8 +4267,8 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
       "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
       "requires": {
-        "inherits": "2.0.3",
-        "statuses": "1.3.1"
+        "inherits": "~2.0.1",
+        "statuses": "1"
       }
     },
     "http-signature": {
@@ -4665,9 +4277,9 @@
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.0",
-        "sshpk": "1.13.1"
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -4697,7 +4309,7 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "infinity-agent": {
@@ -4710,8 +4322,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -4729,19 +4341,19 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.1.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.4",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "lodash": {
@@ -4762,7 +4374,7 @@
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -4781,8 +4393,8 @@
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
       "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
       "requires": {
-        "is-relative": "0.2.1",
-        "is-windows": "0.2.0"
+        "is-relative": "^0.2.1",
+        "is-windows": "^0.2.0"
       }
     },
     "is-arrayish": {
@@ -4797,7 +4409,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "binary-extensions": "1.8.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -4810,7 +4422,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-ci": {
@@ -4819,7 +4431,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "1.0.0"
+        "ci-info": "^1.0.0"
       }
     },
     "is-dotfile": {
@@ -4832,7 +4444,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-error": {
@@ -4856,7 +4468,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -4864,7 +4476,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-generator-fn": {
@@ -4878,7 +4490,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-npm": {
@@ -4891,7 +4503,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-obj": {
@@ -4899,13 +4511,18 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+    },
     "is-observable": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
       "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
       "dev": true,
       "requires": {
-        "symbol-observable": "0.2.4"
+        "symbol-observable": "^0.2.2"
       }
     },
     "is-path-cwd": {
@@ -4918,7 +4535,7 @@
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -4926,7 +4543,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -4965,7 +4582,7 @@
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
       "requires": {
-        "is-unc-path": "0.1.2"
+        "is-unc-path": "^0.1.1"
       }
     },
     "is-retry-allowed": {
@@ -4989,7 +4606,7 @@
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
       "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
       "requires": {
-        "unc-path-regex": "0.1.2"
+        "unc-path-regex": "^0.1.0"
       }
     },
     "is-url": {
@@ -5032,6 +4649,15 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "requires": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
+      }
+    },
     "js-base64": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
@@ -5049,8 +4675,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
       "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "3.1.3"
+        "argparse": "^1.0.7",
+        "esprima": "^3.1.1"
       }
     },
     "jsbn": {
@@ -5078,7 +4704,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -5098,7 +4724,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -5132,7 +4758,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "^1.1.5"
       }
     },
     "last-line-stream": {
@@ -5141,7 +4767,7 @@
       "integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.0"
       }
     },
     "latest-version": {
@@ -5149,7 +4775,7 @@
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
       "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
       "requires": {
-        "package-json": "2.4.0"
+        "package-json": "^2.0.0"
       },
       "dependencies": {
         "package-json": {
@@ -5157,10 +4783,10 @@
           "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
           "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
           "requires": {
-            "got": "5.7.1",
-            "registry-auth-token": "3.3.1",
-            "registry-url": "3.1.0",
-            "semver": "5.3.0"
+            "got": "^5.0.0",
+            "registry-auth-token": "^3.0.1",
+            "registry-url": "^3.0.3",
+            "semver": "^5.1.0"
           }
         },
         "semver": {
@@ -5181,7 +4807,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "liferay-css-parse": {
@@ -5212,18 +4838,18 @@
       "resolved": "https://registry.npmjs.org/liferay-plugin-node-tasks/-/liferay-plugin-node-tasks-1.0.11.tgz",
       "integrity": "sha1-gs8ADbkfpO44/x1HDvSNVQp9Uxw=",
       "requires": {
-        "async": "2.4.1",
+        "async": "^2.0.0-rc.2",
         "gogo-shell": "0.0.5",
-        "gulp": "3.9.1",
-        "gulp-help": "1.6.1",
-        "gulp-storage": "1.0.6",
-        "gulp-util": "3.0.8",
-        "gulp-zip": "3.2.0",
-        "inquirer": "0.12.0",
-        "lodash": "4.17.4",
-        "minimist": "1.2.0",
-        "require-directory": "2.1.1",
-        "run-sequence": "1.2.2"
+        "gulp": "^3.9.1",
+        "gulp-help": "^1.6.1",
+        "gulp-storage": "^1.0.6",
+        "gulp-util": "^3.0.7",
+        "gulp-zip": "^3.2.0",
+        "inquirer": "^0.12.0",
+        "lodash": "^4.6.1",
+        "minimist": "^1.2.0",
+        "require-directory": "^2.1.1",
+        "run-sequence": "^1.1.5"
       },
       "dependencies": {
         "async": {
@@ -5231,7 +4857,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
           "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "lodash": {
@@ -5246,8 +4872,8 @@
       "resolved": "https://registry.npmjs.org/liferay-r2/-/liferay-r2-0.4.4.tgz",
       "integrity": "sha1-zAAFnv37icywIk603cfyc53EJ/s=",
       "requires": {
-        "css-stringify": "1.4.1",
-        "liferay-css-parse": "1.7.1"
+        "css-stringify": "~1.4.0",
+        "liferay-css-parse": "~1.7.1"
       }
     },
     "liferay-theme-deps-6.2": {
@@ -5256,11 +4882,11 @@
       "integrity": "sha1-Uit4zsLXbzgS4gKcxmowTDiJdz8=",
       "dev": true,
       "requires": {
-        "gulp-ruby-sass": "2.1.1",
-        "liferay-theme-deps-normalize": "1.0.0",
-        "liferay-theme-mixins": "6.2.3",
-        "liferay-theme-styled": "6.2.3",
-        "liferay-theme-unstyled": "6.2.4"
+        "gulp-ruby-sass": "^2.0.6",
+        "liferay-theme-deps-normalize": "*",
+        "liferay-theme-mixins": "^6.2.2",
+        "liferay-theme-styled": "^6.2.2",
+        "liferay-theme-unstyled": "^6.2.3"
       }
     },
     "liferay-theme-deps-7.0": {
@@ -5269,12 +4895,12 @@
       "integrity": "sha512-82Fwg5FgE0fQWxs1qnd2DvjiTNNsN/Zms5CzV1O43JKuhNB1EHLDPfhqYuMDW/+YSIcftynV+muN+NvAWL9I3w==",
       "dev": true,
       "requires": {
-        "compass-mixins": "0.12.10",
-        "gulp-sass": "3.1.0",
-        "liferay-frontend-common-css": "1.0.4",
-        "liferay-frontend-theme-styled": "2.0.25",
-        "liferay-frontend-theme-unstyled": "2.1.9",
-        "liferay-theme-deps-normalize": "1.0.0"
+        "compass-mixins": "^0.12.7",
+        "gulp-sass": "~3.1.0",
+        "liferay-frontend-common-css": "~1.0.4",
+        "liferay-frontend-theme-styled": "~2.0.0",
+        "liferay-frontend-theme-unstyled": "~2.1.0",
+        "liferay-theme-deps-normalize": "*"
       }
     },
     "liferay-theme-deps-normalize": {
@@ -5306,15 +4932,15 @@
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
       "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
       "requires": {
-        "extend": "3.0.1",
-        "findup-sync": "0.4.3",
-        "fined": "1.0.2",
-        "flagged-respawn": "0.3.2",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.isstring": "4.0.1",
-        "lodash.mapvalues": "4.6.0",
-        "rechoir": "0.6.2",
-        "resolve": "1.3.3"
+        "extend": "^3.0.0",
+        "findup-sync": "^0.4.2",
+        "fined": "^1.0.1",
+        "flagged-respawn": "^0.3.2",
+        "lodash.isplainobject": "^4.0.4",
+        "lodash.isstring": "^4.0.1",
+        "lodash.mapvalues": "^4.4.0",
+        "rechoir": "^0.6.2",
+        "resolve": "^1.1.7"
       },
       "dependencies": {
         "findup-sync": {
@@ -5322,10 +4948,10 @@
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
           "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
           "requires": {
-            "detect-file": "0.1.0",
-            "is-glob": "2.0.1",
-            "micromatch": "2.3.11",
-            "resolve-dir": "0.1.1"
+            "detect-file": "^0.1.0",
+            "is-glob": "^2.0.1",
+            "micromatch": "^2.3.7",
+            "resolve-dir": "^0.1.0"
           }
         }
       }
@@ -5340,11 +4966,11 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "lodash": {
@@ -5357,8 +4983,8 @@
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -5386,9 +5012,9 @@
       "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
       "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
       }
     },
     "lodash._escapehtmlchar": {
@@ -5396,7 +5022,7 @@
       "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
       "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
       "requires": {
-        "lodash._htmlescapes": "2.4.1"
+        "lodash._htmlescapes": "~2.4.1"
       }
     },
     "lodash._escapestringchar": {
@@ -5449,8 +5075,8 @@
       "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
       "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
       "requires": {
-        "lodash._htmlescapes": "2.4.1",
-        "lodash.keys": "2.4.1"
+        "lodash._htmlescapes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -5458,9 +5084,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
           }
         }
       }
@@ -5475,7 +5101,7 @@
       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
       "requires": {
-        "lodash._objecttypes": "2.4.1"
+        "lodash._objecttypes": "~2.4.1"
       }
     },
     "lodash.assign": {
@@ -5483,9 +5109,9 @@
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
       "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._createassigner": "3.1.1",
-        "lodash.keys": "3.1.2"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._createassigner": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash.assignwith": {
@@ -5510,8 +5136,8 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
       "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
       "requires": {
-        "lodash._objecttypes": "2.4.1",
-        "lodash.keys": "2.4.1"
+        "lodash._objecttypes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -5519,9 +5145,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
           }
         }
       }
@@ -5531,7 +5157,7 @@
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "requires": {
-        "lodash._root": "3.0.1"
+        "lodash._root": "^3.0.0"
       }
     },
     "lodash.isarguments": {
@@ -5554,7 +5180,7 @@
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "requires": {
-        "lodash._objecttypes": "2.4.1"
+        "lodash._objecttypes": "~2.4.1"
       }
     },
     "lodash.isplainobject": {
@@ -5572,9 +5198,9 @@
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.mapvalues": {
@@ -5603,15 +5229,15 @@
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash._basetostring": "3.0.1",
-        "lodash._basevalues": "3.0.0",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0",
-        "lodash.keys": "3.1.2",
-        "lodash.restparam": "3.6.1",
-        "lodash.templatesettings": "3.1.1"
+        "lodash._basecopy": "^3.0.0",
+        "lodash._basetostring": "^3.0.0",
+        "lodash._basevalues": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.escape": "^3.0.0",
+        "lodash.keys": "^3.0.0",
+        "lodash.restparam": "^3.0.0",
+        "lodash.templatesettings": "^3.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -5619,8 +5245,8 @@
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0"
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.escape": "^3.0.0"
       }
     },
     "lodash.values": {
@@ -5628,7 +5254,7 @@
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
       "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
       "requires": {
-        "lodash.keys": "2.4.1"
+        "lodash.keys": "~2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -5636,9 +5262,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
           }
         }
       }
@@ -5655,7 +5281,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.1"
+        "js-tokens": "^3.0.0"
       }
     },
     "loud-rejection": {
@@ -5663,8 +5289,8 @@
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -5677,8 +5303,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "map-cache": {
@@ -5702,7 +5328,7 @@
       "integrity": "sha1-7yDL3mTCTFDMYa9bg+4LG4/wAQE=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.4"
       }
     },
     "max-timeout": {
@@ -5717,7 +5343,7 @@
       "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
       "dev": true,
       "requires": {
-        "md5-o-matic": "0.1.1"
+        "md5-o-matic": "^0.1.1"
       }
     },
     "md5-o-matic": {
@@ -5736,9 +5362,9 @@
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
       "integrity": "sha1-u0WnrQJTAILxYSZx2rNSGc0uB0E=",
       "requires": {
-        "es5-ext": "0.9.2",
-        "event-emitter": "0.2.2",
-        "next-tick": "0.1.0"
+        "es5-ext": "~0.9.2",
+        "event-emitter": "~0.2.2",
+        "next-tick": "0.1.x"
       }
     },
     "meow": {
@@ -5746,16 +5372,16 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.3.8",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "object-assign": {
@@ -5770,7 +5396,7 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz",
       "integrity": "sha1-SKB7O0oSHXSj7b/c20sIrb8CQLE=",
       "requires": {
-        "through2": "0.6.5"
+        "through2": "^0.6.1"
       },
       "dependencies": {
         "isarray": {
@@ -5783,10 +5409,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -5799,8 +5425,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -5810,19 +5436,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "mime-db": {
@@ -5835,20 +5461,25 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
       "requires": {
-        "mime-db": "1.27.0"
+        "mime-db": "~1.27.0"
       }
+    },
+    "mimic-response": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
     },
     "mini-lr": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/mini-lr/-/mini-lr-0.1.9.tgz",
       "integrity": "sha1-AhmdJzR5U9H9HW297UJh8Yey0PY=",
       "requires": {
-        "body-parser": "1.14.2",
-        "debug": "2.6.8",
-        "faye-websocket": "0.7.3",
-        "livereload-js": "2.2.2",
-        "parseurl": "1.3.1",
-        "qs": "2.2.5"
+        "body-parser": "~1.14.0",
+        "debug": "^2.2.0",
+        "faye-websocket": "~0.7.2",
+        "livereload-js": "^2.2.0",
+        "parseurl": "~1.3.0",
+        "qs": "~2.2.3"
       }
     },
     "minimatch": {
@@ -5856,7 +5487,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -5889,10 +5520,10 @@
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
       }
     },
     "multipipe": {
@@ -5924,7 +5555,7 @@
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
       "integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.1"
       }
     },
     "next-tick": {
@@ -5946,19 +5577,19 @@
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.0",
-        "osenv": "0.1.4",
-        "request": "2.81.0",
-        "rimraf": "2.6.1",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.2.14"
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "2",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
       },
       "dependencies": {
         "semver": {
@@ -5975,24 +5606,24 @@
       "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
       "dev": true,
       "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.2",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.0",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.6.2",
-        "node-gyp": "3.6.2",
-        "npmlog": "4.1.0",
-        "request": "2.81.0",
-        "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.0"
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.clonedeep": "^4.3.2",
+        "lodash.mergewith": "^4.6.0",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.3.2",
+        "node-gyp": "^3.3.1",
+        "npmlog": "^4.0.0",
+        "request": "^2.79.0",
+        "sass-graph": "^2.1.1",
+        "stdout-stream": "^1.4.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -6001,8 +5632,8 @@
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.1",
-            "which": "1.2.14"
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
           }
         },
         "gaze": {
@@ -6011,7 +5642,7 @@
           "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
           "dev": true,
           "requires": {
-            "globule": "1.2.0"
+            "globule": "^1.0.0"
           }
         },
         "globule": {
@@ -6020,9 +5651,9 @@
           "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
           "dev": true,
           "requires": {
-            "glob": "7.1.2",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4"
+            "glob": "~7.1.1",
+            "lodash": "~4.17.4",
+            "minimatch": "~3.0.2"
           }
         },
         "lodash": {
@@ -6050,7 +5681,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.0"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -6058,10 +5689,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
       "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
       "requires": {
-        "hosted-git-info": "2.4.2",
-        "is-builtin-module": "1.0.0",
-        "semver": "4.3.6",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -6069,7 +5700,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "1.0.2"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "not-so-shallow": {
@@ -6078,24 +5709,43 @@
       "integrity": "sha1-6Mf3ucm58GlZQ0Q2gzDLzqOHw8c=",
       "dev": true,
       "requires": {
-        "buffer-equals": "1.0.4"
+        "buffer-equals": "^1.0.3"
       }
     },
     "npm-keyword": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/npm-keyword/-/npm-keyword-4.2.0.tgz",
-      "integrity": "sha1-mP/r/bsTNvJ+9f4brKDcrNCs9sA=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-keyword/-/npm-keyword-5.0.0.tgz",
+      "integrity": "sha1-mbha7Cn8s4jS3TUfABO/Umh4fmc=",
       "requires": {
-        "got": "5.7.1",
-        "object-assign": "4.1.1",
-        "pinkie-promise": "2.0.1",
-        "registry-url": "3.1.0"
+        "got": "^7.1.0",
+        "registry-url": "^3.0.3"
       },
       "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        "got": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+          "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+          "requires": {
+            "decompress-response": "^3.2.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "p-cancelable": "^0.3.0",
+            "p-timeout": "^1.1.1",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "url-parse-lax": "^1.0.0",
+            "url-to-options": "^1.0.1"
+          }
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         }
       }
     },
@@ -6105,10 +5755,10 @@
       "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -6122,75 +5772,82 @@
       "integrity": "sha1-L2AUYQpXBwAhxMBn6bnjMKI6xqc=",
       "dev": true,
       "requires": {
-        "append-transform": "0.4.0",
-        "arrify": "1.0.1",
-        "caching-transform": "1.0.1",
-        "convert-source-map": "1.2.0",
-        "default-require-extensions": "1.0.0",
-        "find-cache-dir": "0.1.1",
-        "find-up": "1.1.2",
-        "foreground-child": "1.5.1",
-        "glob": "7.0.3",
-        "istanbul": "0.4.3",
-        "md5-hex": "1.3.0",
-        "micromatch": "2.3.8",
-        "mkdirp": "0.5.1",
-        "pkg-up": "1.0.0",
-        "resolve-from": "2.0.0",
-        "rimraf": "2.5.2",
-        "signal-exit": "3.0.0",
-        "source-map": "0.5.6",
-        "spawn-wrap": "1.2.3",
-        "test-exclude": "1.1.0",
-        "yargs": "4.7.1"
+        "append-transform": "^0.4.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^1.0.0",
+        "convert-source-map": "^1.1.2",
+        "default-require-extensions": "^1.0.0",
+        "find-cache-dir": "^0.1.1",
+        "find-up": "^1.1.2",
+        "foreground-child": "^1.5.1",
+        "glob": "^7.0.3",
+        "istanbul": "^0.4.3",
+        "md5-hex": "^1.2.0",
+        "micromatch": "^2.3.7",
+        "mkdirp": "^0.5.0",
+        "pkg-up": "^1.0.0",
+        "resolve-from": "^2.0.0",
+        "rimraf": "^2.5.0",
+        "signal-exit": "^3.0.0",
+        "source-map": "^0.5.3",
+        "spawn-wrap": "^1.2.2",
+        "test-exclude": "^1.1.0",
+        "yargs": "^4.7.0"
       },
       "dependencies": {
         "append-transform": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
           "dev": true,
           "requires": {
-            "default-require-extensions": "1.0.0"
+            "default-require-extensions": "^1.0.0"
           }
         },
         "arrify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
         "caching-transform": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
           "dev": true,
           "requires": {
-            "md5-hex": "1.3.0",
-            "mkdirp": "0.5.1",
-            "write-file-atomic": "1.1.4"
+            "md5-hex": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "write-file-atomic": "^1.1.4"
           },
           "dependencies": {
             "write-file-atomic": {
               "version": "1.1.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.4",
-                "imurmurhash": "0.1.4",
-                "slide": "1.1.6"
+                "graceful-fs": "^4.1.2",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
               },
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
                   "dev": true
                 },
                 "imurmurhash": {
                   "version": "0.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
                   "dev": true
                 },
                 "slide": {
                   "version": "1.1.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
                   "dev": true
                 }
               }
@@ -6199,28 +5856,32 @@
         },
         "convert-source-map": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RMCMJQbxD7PKb9iI1aNETPjWpmk=",
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
           "dev": true,
           "requires": {
-            "strip-bom": "2.0.0"
+            "strip-bom": "^2.0.0"
           },
           "dependencies": {
             "strip-bom": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
               "dev": true,
               "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
               },
               "dependencies": {
                 "is-utf8": {
                   "version": "0.2.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
                   "dev": true
                 }
               }
@@ -6229,57 +5890,64 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
           },
           "dependencies": {
             "commondir": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
               "dev": true
             },
             "pkg-dir": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
               "dev": true,
               "requires": {
-                "find-up": "1.1.2"
+                "find-up": "^1.0.0"
               }
             }
           }
         },
         "find-up": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
             "path-exists": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
               "dev": true,
               "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
               }
             },
             "pinkie-promise": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
               "dev": true,
               "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
               },
               "dependencies": {
                 "pinkie": {
                   "version": "2.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
                   "dev": true
                 }
               }
@@ -6288,40 +5956,45 @@
         },
         "foreground-child": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-76NNl4DSV8dQsR4pbi4e3BT/+qo=",
           "dev": true,
           "requires": {
-            "cross-spawn-async": "2.2.4",
-            "signal-exit": "2.1.2",
-            "which": "1.2.10"
+            "cross-spawn-async": "^2.1.1",
+            "signal-exit": "^2.0.0",
+            "which": "^1.2.1"
           },
           "dependencies": {
             "cross-spawn-async": {
               "version": "2.2.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-yajY6aBlAsekYpbjOhoFS10vGBI=",
               "dev": true,
               "requires": {
-                "lru-cache": "4.0.1",
-                "which": "1.2.10"
+                "lru-cache": "^4.0.0",
+                "which": "^1.2.8"
               },
               "dependencies": {
                 "lru-cache": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
                   "dev": true,
                   "requires": {
-                    "pseudomap": "1.0.2",
-                    "yallist": "2.0.0"
+                    "pseudomap": "^1.0.1",
+                    "yallist": "^2.0.0"
                   },
                   "dependencies": {
                     "pseudomap": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                       "dev": true
                     },
                     "yallist": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
                       "dev": true
                     }
                   }
@@ -6330,20 +6003,23 @@
             },
             "signal-exit": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ=",
               "dev": true
             },
             "which": {
               "version": "1.2.10",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
               "dev": true,
               "requires": {
-                "isexe": "1.1.2"
+                "isexe": "^1.1.1"
               },
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
                   "dev": true
                 }
               }
@@ -6352,62 +6028,70 @@
         },
         "glob": {
           "version": "7.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.5",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.0",
-            "once": "1.3.3",
-            "path-is-absolute": "1.0.0"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           },
           "dependencies": {
             "inflight": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
               "dev": true,
               "requires": {
-                "once": "1.3.3",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               },
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                   "dev": true
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
               "dev": true
             },
             "minimatch": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.4"
+                "brace-expansion": "^1.0.0"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "0.4.1",
+                    "balanced-match": "^0.4.1",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU=",
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                       "dev": true
                     }
                   }
@@ -6416,138 +6100,155 @@
             },
             "once": {
               "version": "1.3.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
               "dev": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               },
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                   "dev": true
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
               "dev": true
             }
           }
         },
         "istanbul": {
           "version": "0.4.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-W3FO4K5JOsXvIEuZ84crzu9z1To=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.7",
-            "async": "1.5.2",
-            "escodegen": "1.8.0",
-            "esprima": "2.7.2",
-            "fileset": "0.2.1",
-            "handlebars": "4.0.5",
-            "js-yaml": "3.6.1",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "once": "1.3.3",
-            "resolve": "1.1.7",
-            "supports-color": "3.1.2",
-            "which": "1.2.10",
-            "wordwrap": "1.0.0"
+            "abbrev": "1.0.x",
+            "async": "1.x",
+            "escodegen": "1.8.x",
+            "esprima": "2.7.x",
+            "fileset": "0.2.x",
+            "handlebars": "^4.0.1",
+            "js-yaml": "3.x",
+            "mkdirp": "0.5.x",
+            "nopt": "3.x",
+            "once": "1.x",
+            "resolve": "1.1.x",
+            "supports-color": "^3.1.0",
+            "which": "^1.1.1",
+            "wordwrap": "^1.0.0"
           },
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
               "dev": true
             },
             "async": {
               "version": "1.5.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
               "dev": true
             },
             "escodegen": {
               "version": "1.8.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-skaq6CnOc9WeLFVyc1nt0cEwqBs=",
               "dev": true,
               "requires": {
-                "esprima": "2.7.2",
-                "estraverse": "1.9.3",
-                "esutils": "2.0.2",
-                "optionator": "0.8.1",
-                "source-map": "0.2.0"
+                "esprima": "^2.7.1",
+                "estraverse": "^1.9.1",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.2.0"
               },
               "dependencies": {
                 "estraverse": {
                   "version": "1.9.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
                   "dev": true
                 },
                 "esutils": {
                   "version": "2.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
                   "dev": true
                 },
                 "optionator": {
                   "version": "0.8.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-4xtJMs3V+4Yqiw0QvGPT7h7H14s=",
                   "dev": true,
                   "requires": {
-                    "deep-is": "0.1.3",
-                    "fast-levenshtein": "1.1.3",
-                    "levn": "0.3.0",
-                    "prelude-ls": "1.1.2",
-                    "type-check": "0.3.2",
-                    "wordwrap": "1.0.0"
+                    "deep-is": "~0.1.3",
+                    "fast-levenshtein": "^1.1.0",
+                    "levn": "~0.3.0",
+                    "prelude-ls": "~1.1.2",
+                    "type-check": "~0.3.2",
+                    "wordwrap": "~1.0.0"
                   },
                   "dependencies": {
                     "deep-is": {
                       "version": "0.1.3",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
                       "dev": true
                     },
                     "fast-levenshtein": {
                       "version": "1.1.3",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-KuezKrweYS2kik4ThJuIii9h5+k=",
                       "dev": true
                     },
                     "levn": {
                       "version": "0.3.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
                       "dev": true,
                       "requires": {
-                        "prelude-ls": "1.1.2",
-                        "type-check": "0.3.2"
+                        "prelude-ls": "~1.1.2",
+                        "type-check": "~0.3.2"
                       }
                     },
                     "prelude-ls": {
                       "version": "1.1.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
                       "dev": true
                     },
                     "type-check": {
                       "version": "0.3.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
                       "dev": true,
                       "requires": {
-                        "prelude-ls": "1.1.2"
+                        "prelude-ls": "~1.1.2"
                       }
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "amdefine": "1.0.0"
+                    "amdefine": ">=0.0.4"
                   },
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
                       "dev": true,
                       "optional": true
                     }
@@ -6557,83 +6258,94 @@
             },
             "esprima": {
               "version": "2.7.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-9DvlQ2CZhOrkTJM6xjNSpq818zk=",
               "dev": true
             },
             "fileset": {
               "version": "0.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
               "dev": true,
               "requires": {
-                "glob": "5.0.15",
-                "minimatch": "2.0.10"
+                "glob": "5.x",
+                "minimatch": "2.x"
               },
               "dependencies": {
                 "glob": {
                   "version": "5.0.15",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.5",
-                    "inherits": "2.0.1",
-                    "minimatch": "2.0.10",
-                    "once": "1.3.3",
-                    "path-is-absolute": "1.0.0"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.5",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
                       "dev": true,
                       "requires": {
-                        "once": "1.3.3",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                       },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                           "dev": true
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
                       "dev": true
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                       "dev": true
                     }
                   }
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.4"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.4",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.4.1",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -6644,143 +6356,160 @@
             },
             "handlebars": {
               "version": "4.0.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
               "dev": true,
               "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.6.2"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
               },
               "dependencies": {
                 "optimist": {
                   "version": "0.6.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
                   "dev": true,
                   "requires": {
-                    "minimist": "0.0.10",
-                    "wordwrap": "0.0.3"
+                    "minimist": "~0.0.1",
+                    "wordwrap": "~0.0.2"
                   },
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.10",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
                       "dev": true
                     },
                     "wordwrap": {
                       "version": "0.0.3",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
                       "dev": true
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.4.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                   "dev": true,
                   "requires": {
-                    "amdefine": "1.0.0"
+                    "amdefine": ">=0.0.4"
                   },
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
                       "dev": true
                     }
                   }
                 },
                 "uglify-js": {
                   "version": "2.6.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-9QvoikLNOWpiUdxSqzcvccwS/vA=",
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "async": "0.2.10",
-                    "source-map": "0.5.6",
-                    "uglify-to-browserify": "1.0.2",
-                    "yargs": "3.10.0"
+                    "async": "~0.2.6",
+                    "source-map": "~0.5.1",
+                    "uglify-to-browserify": "~1.0.0",
+                    "yargs": "~3.10.0"
                   },
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
                       "dev": true,
                       "optional": true
                     },
                     "source-map": {
                       "version": "0.5.6",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
                       "dev": true,
                       "optional": true
                     },
                     "uglify-to-browserify": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
                       "dev": true,
                       "optional": true
                     },
                     "yargs": {
                       "version": "3.10.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "2.1.0",
-                        "decamelize": "1.2.0",
+                        "camelcase": "^1.0.2",
+                        "cliui": "^2.1.0",
+                        "decamelize": "^1.0.0",
                         "window-size": "0.1.0"
                       },
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
                           "dev": true,
                           "optional": true
                         },
                         "cliui": {
                           "version": "2.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                           "dev": true,
                           "optional": true,
                           "requires": {
-                            "center-align": "0.1.3",
-                            "right-align": "0.1.3",
+                            "center-align": "^0.1.1",
+                            "right-align": "^0.1.1",
                             "wordwrap": "0.0.2"
                           },
                           "dependencies": {
                             "center-align": {
                               "version": "0.1.3",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
                               "dev": true,
                               "optional": true,
                               "requires": {
-                                "align-text": "0.1.4",
-                                "lazy-cache": "1.0.4"
+                                "align-text": "^0.1.3",
+                                "lazy-cache": "^1.0.3"
                               },
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                                   "dev": true,
                                   "optional": true,
                                   "requires": {
-                                    "kind-of": "3.0.3",
-                                    "longest": "1.0.1",
-                                    "repeat-string": "1.5.4"
+                                    "kind-of": "^3.0.2",
+                                    "longest": "^1.0.1",
+                                    "repeat-string": "^1.5.2"
                                   },
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.3",
-                                      "bundled": true,
+                                      "resolved": false,
+                                      "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
                                       "dev": true,
                                       "optional": true,
                                       "requires": {
-                                        "is-buffer": "1.1.3"
+                                        "is-buffer": "^1.0.2"
                                       },
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
-                                          "bundled": true,
+                                          "resolved": false,
+                                          "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
                                           "dev": true,
                                           "optional": true
                                         }
@@ -6788,13 +6517,15 @@
                                     },
                                     "longest": {
                                       "version": "1.0.1",
-                                      "bundled": true,
+                                      "resolved": false,
+                                      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
                                       "dev": true,
                                       "optional": true
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
-                                      "bundled": true,
+                                      "resolved": false,
+                                      "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
                                       "dev": true,
                                       "optional": true
                                     }
@@ -6802,7 +6533,8 @@
                                 },
                                 "lazy-cache": {
                                   "version": "1.0.4",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
                                   "dev": true,
                                   "optional": true
                                 }
@@ -6810,36 +6542,40 @@
                             },
                             "right-align": {
                               "version": "0.1.3",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
                               "dev": true,
                               "optional": true,
                               "requires": {
-                                "align-text": "0.1.4"
+                                "align-text": "^0.1.1"
                               },
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                                   "dev": true,
                                   "optional": true,
                                   "requires": {
-                                    "kind-of": "3.0.3",
-                                    "longest": "1.0.1",
-                                    "repeat-string": "1.5.4"
+                                    "kind-of": "^3.0.2",
+                                    "longest": "^1.0.1",
+                                    "repeat-string": "^1.5.2"
                                   },
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.3",
-                                      "bundled": true,
+                                      "resolved": false,
+                                      "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
                                       "dev": true,
                                       "optional": true,
                                       "requires": {
-                                        "is-buffer": "1.1.3"
+                                        "is-buffer": "^1.0.2"
                                       },
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
-                                          "bundled": true,
+                                          "resolved": false,
+                                          "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
                                           "dev": true,
                                           "optional": true
                                         }
@@ -6847,13 +6583,15 @@
                                     },
                                     "longest": {
                                       "version": "1.0.1",
-                                      "bundled": true,
+                                      "resolved": false,
+                                      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
                                       "dev": true,
                                       "optional": true
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
-                                      "bundled": true,
+                                      "resolved": false,
+                                      "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
                                       "dev": true,
                                       "optional": true
                                     }
@@ -6863,7 +6601,8 @@
                             },
                             "wordwrap": {
                               "version": "0.0.2",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
                               "dev": true,
                               "optional": true
                             }
@@ -6871,13 +6610,15 @@
                         },
                         "decamelize": {
                           "version": "1.2.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
                           "dev": true,
                           "optional": true
                         },
                         "window-size": {
                           "version": "0.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
                           "dev": true,
                           "optional": true
                         }
@@ -6889,24 +6630,27 @@
             },
             "js-yaml": {
               "version": "3.6.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
               "dev": true,
               "requires": {
-                "argparse": "1.0.7",
-                "esprima": "2.7.2"
+                "argparse": "^1.0.7",
+                "esprima": "^2.6.0"
               },
               "dependencies": {
                 "argparse": {
                   "version": "1.0.7",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
                   "dev": true,
                   "requires": {
-                    "sprintf-js": "1.0.3"
+                    "sprintf-js": "~1.0.2"
                   },
                   "dependencies": {
                     "sprintf-js": {
                       "version": "1.0.3",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
                       "dev": true
                     }
                   }
@@ -6915,165 +6659,185 @@
             },
             "nopt": {
               "version": "3.0.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
               "dev": true,
               "requires": {
-                "abbrev": "1.0.7"
+                "abbrev": "1"
               }
             },
             "once": {
               "version": "1.3.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
               "dev": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               },
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                   "dev": true
                 }
               }
             },
             "resolve": {
               "version": "1.1.7",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
               "dev": true
             },
             "supports-color": {
               "version": "3.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
               "dev": true,
               "requires": {
-                "has-flag": "1.0.0"
+                "has-flag": "^1.0.0"
               },
               "dependencies": {
                 "has-flag": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
                   "dev": true
                 }
               }
             },
             "which": {
               "version": "1.2.10",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
               "dev": true,
               "requires": {
-                "isexe": "1.1.2"
+                "isexe": "^1.1.1"
               },
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
                   "dev": true
                 }
               }
             },
             "wordwrap": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
               "dev": true
             }
           }
         },
         "md5-hex": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
-            "md5-o-matic": "0.1.1"
+            "md5-o-matic": "^0.1.1"
           },
           "dependencies": {
             "md5-o-matic": {
               "version": "0.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
               "dev": true
             }
           }
         },
         "micromatch": {
           "version": "2.3.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lPv4837Z7eyga/HI97dD+19vWFQ=",
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.0",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.0.3",
-            "normalize-path": "2.0.1",
-            "object.omit": "2.0.0",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.3"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           },
           "dependencies": {
             "arr-diff": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
               "dev": true,
               "requires": {
-                "arr-flatten": "1.0.1"
+                "arr-flatten": "^1.0.1"
               },
               "dependencies": {
                 "arr-flatten": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
                   "dev": true
                 }
               }
             },
             "array-unique": {
               "version": "0.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
               "dev": true
             },
             "braces": {
               "version": "1.8.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
               "dev": true,
               "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
               },
               "dependencies": {
                 "expand-range": {
                   "version": "1.8.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
                   "dev": true,
                   "requires": {
-                    "fill-range": "2.2.3"
+                    "fill-range": "^2.1.0"
                   },
                   "dependencies": {
                     "fill-range": {
                       "version": "2.2.3",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
                       "dev": true,
                       "requires": {
-                        "is-number": "2.1.0",
-                        "isobject": "2.1.0",
-                        "randomatic": "1.1.5",
-                        "repeat-element": "1.1.2",
-                        "repeat-string": "1.5.4"
+                        "is-number": "^2.1.0",
+                        "isobject": "^2.0.0",
+                        "randomatic": "^1.1.3",
+                        "repeat-element": "^1.1.2",
+                        "repeat-string": "^1.5.2"
                       },
                       "dependencies": {
                         "is-number": {
                           "version": "2.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                           "dev": true,
                           "requires": {
-                            "kind-of": "3.0.3"
+                            "kind-of": "^3.0.2"
                           }
                         },
                         "isobject": {
                           "version": "2.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
                           "dev": true,
                           "requires": {
                             "isarray": "1.0.0"
@@ -7081,23 +6845,26 @@
                           "dependencies": {
                             "isarray": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                               "dev": true
                             }
                           }
                         },
                         "randomatic": {
                           "version": "1.1.5",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-Xp718tVzxnvSuBJK6QtRVuRXhAs=",
                           "dev": true,
                           "requires": {
-                            "is-number": "2.1.0",
-                            "kind-of": "3.0.3"
+                            "is-number": "^2.0.2",
+                            "kind-of": "^3.0.2"
                           }
                         },
                         "repeat-string": {
                           "version": "1.5.4",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
                           "dev": true
                         }
                       }
@@ -7106,165 +6873,187 @@
                 },
                 "preserve": {
                   "version": "0.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
                   "dev": true
                 },
                 "repeat-element": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
                   "dev": true
                 }
               }
             },
             "expand-brackets": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
               "dev": true,
               "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
               },
               "dependencies": {
                 "is-posix-bracket": {
                   "version": "0.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
                   "dev": true
                 }
               }
             },
             "extglob": {
               "version": "0.3.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             },
             "filename-regex": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
               "dev": true
             },
             "is-extglob": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
               "dev": true
             },
             "is-glob": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             },
             "kind-of": {
               "version": "3.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.3"
+                "is-buffer": "^1.0.2"
               },
               "dependencies": {
                 "is-buffer": {
                   "version": "1.1.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
                   "dev": true
                 }
               }
             },
             "normalize-path": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o=",
               "dev": true
             },
             "object.omit": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-hoWXMz1U5gZilAu0WGBd1q4S/pQ=",
               "dev": true,
               "requires": {
-                "for-own": "0.1.4",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.3",
+                "is-extendable": "^0.1.1"
               },
               "dependencies": {
                 "for-own": {
                   "version": "0.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
                   "dev": true,
                   "requires": {
-                    "for-in": "0.1.5"
+                    "for-in": "^0.1.5"
                   },
                   "dependencies": {
                     "for-in": {
                       "version": "0.1.5",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-AHN04rbVxnQgoUeb23WgSHK3OMQ=",
                       "dev": true
                     }
                   }
                 },
                 "is-extendable": {
                   "version": "0.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
                   "dev": true
                 }
               }
             },
             "parse-glob": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
               "dev": true,
               "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.2",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
               },
               "dependencies": {
                 "glob-base": {
                   "version": "0.3.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
                   "dev": true,
                   "requires": {
-                    "glob-parent": "2.0.0",
-                    "is-glob": "2.0.1"
+                    "glob-parent": "^2.0.0",
+                    "is-glob": "^2.0.0"
                   },
                   "dependencies": {
                     "glob-parent": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                       "dev": true,
                       "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                       }
                     }
                   }
                 },
                 "is-dotfile": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
                   "dev": true
                 }
               }
             },
             "regex-cache": {
               "version": "0.4.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
               "dev": true,
               "requires": {
-                "is-equal-shallow": "0.1.3",
-                "is-primitive": "2.0.0"
+                "is-equal-shallow": "^0.1.3",
+                "is-primitive": "^2.0.0"
               },
               "dependencies": {
                 "is-equal-shallow": {
                   "version": "0.1.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
                   "dev": true,
                   "requires": {
-                    "is-primitive": "2.0.0"
+                    "is-primitive": "^2.0.0"
                   }
                 },
                 "is-primitive": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
                   "dev": true
                 }
               }
@@ -7273,7 +7062,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -7281,76 +7071,87 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
           }
         },
         "pkg-up": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         },
         "resolve-from": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
         },
         "rimraf": {
           "version": "2.5.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
           "dev": true,
           "requires": {
-            "glob": "7.0.3"
+            "glob": "^7.0.0"
           }
         },
         "signal-exit": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PAVDtl17T7xgts2UWT2b9DZzm+g=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.2.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-3300R/tKAZYZpB9o7mQqcY5gYuk=",
           "dev": true,
           "requires": {
-            "foreground-child": "1.5.1",
-            "mkdirp": "0.5.1",
-            "os-homedir": "1.0.1",
-            "rimraf": "2.5.2",
-            "signal-exit": "2.1.2",
-            "which": "1.2.10"
+            "foreground-child": "^1.3.3",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.3.3",
+            "signal-exit": "^2.0.0",
+            "which": "^1.2.4"
           },
           "dependencies": {
             "os-homedir": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
               "dev": true
             },
             "signal-exit": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ=",
               "dev": true
             },
             "which": {
               "version": "1.2.10",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
               "dev": true,
               "requires": {
-                "isexe": "1.1.2"
+                "isexe": "^1.1.1"
               },
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
                   "dev": true
                 }
               }
@@ -7359,92 +7160,103 @@
         },
         "test-exclude": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-9d3XGJJ7Ev0C8nCgqpOc627qQVE=",
           "dev": true,
           "requires": {
-            "arrify": "1.0.1",
-            "lodash.assign": "4.0.9",
-            "micromatch": "2.3.8",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
+            "arrify": "^1.0.1",
+            "lodash.assign": "^4.0.9",
+            "micromatch": "^2.3.8",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
           },
           "dependencies": {
             "lodash.assign": {
               "version": "4.0.9",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Cgcx2TWQ3dm6RYn61lqvbuCSF+M=",
               "dev": true,
               "requires": {
-                "lodash.keys": "4.0.7",
-                "lodash.rest": "4.0.3"
+                "lodash.keys": "^4.0.0",
+                "lodash.rest": "^4.0.0"
               },
               "dependencies": {
                 "lodash.keys": {
                   "version": "4.0.7",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-MOGzvZjlTWoGEZkYEmhba8R8tjs=",
                   "dev": true
                 },
                 "lodash.rest": {
                   "version": "4.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-TBwyxAAoCHJQ+r9w1C4BUVSPSMU=",
                   "dev": true
                 }
               }
             },
             "read-pkg-up": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
               "dev": true,
               "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
               },
               "dependencies": {
                 "read-pkg": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                   "dev": true,
                   "requires": {
-                    "load-json-file": "1.1.0",
-                    "normalize-package-data": "2.3.5",
-                    "path-type": "1.1.0"
+                    "load-json-file": "^1.0.0",
+                    "normalize-package-data": "^2.3.2",
+                    "path-type": "^1.0.0"
                   },
                   "dependencies": {
                     "load-json-file": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                       "dev": true,
                       "requires": {
-                        "graceful-fs": "4.1.4",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                       },
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
                           "dev": true
                         },
                         "parse-json": {
                           "version": "2.2.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                           "dev": true,
                           "requires": {
-                            "error-ex": "1.3.0"
+                            "error-ex": "^1.2.0"
                           },
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
                               "dev": true,
                               "requires": {
-                                "is-arrayish": "0.2.1"
+                                "is-arrayish": "^0.2.1"
                               },
                               "dependencies": {
                                 "is-arrayish": {
                                   "version": "0.2.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
                                   "dev": true
                                 }
                               }
@@ -7453,35 +7265,40 @@
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                           "dev": true
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                           "dev": true,
                           "requires": {
-                            "pinkie": "2.0.4"
+                            "pinkie": "^2.0.0"
                           },
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
                               "dev": true
                             }
                           }
                         },
                         "strip-bom": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                           "dev": true,
                           "requires": {
-                            "is-utf8": "0.2.1"
+                            "is-utf8": "^0.2.0"
                           },
                           "dependencies": {
                             "is-utf8": {
                               "version": "0.2.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
                               "dev": true
                             }
                           }
@@ -7490,81 +7307,92 @@
                     },
                     "normalize-package-data": {
                       "version": "2.3.5",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
                       "dev": true,
                       "requires": {
-                        "hosted-git-info": "2.1.5",
-                        "is-builtin-module": "1.0.0",
-                        "semver": "5.1.0",
-                        "validate-npm-package-license": "3.0.1"
+                        "hosted-git-info": "^2.1.4",
+                        "is-builtin-module": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
                       },
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.5",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
                           "dev": true
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                           "dev": true,
                           "requires": {
-                            "builtin-modules": "1.1.1"
+                            "builtin-modules": "^1.0.0"
                           },
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
                               "dev": true
                             }
                           }
                         },
                         "semver": {
                           "version": "5.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
                           "dev": true
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
                           "dev": true,
                           "requires": {
-                            "spdx-correct": "1.0.2",
-                            "spdx-expression-parse": "1.0.2"
+                            "spdx-correct": "~1.0.0",
+                            "spdx-expression-parse": "~1.0.0"
                           },
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                               "dev": true,
                               "requires": {
-                                "spdx-license-ids": "1.2.1"
+                                "spdx-license-ids": "^1.0.2"
                               },
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM=",
                                   "dev": true
                                 }
                               }
                             },
                             "spdx-expression-parse": {
                               "version": "1.0.2",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
                               "dev": true,
                               "requires": {
-                                "spdx-exceptions": "1.0.4",
-                                "spdx-license-ids": "1.2.1"
+                                "spdx-exceptions": "^1.0.4",
+                                "spdx-license-ids": "^1.0.0"
                               },
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.4",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
                                   "dev": true
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM=",
                                   "dev": true
                                 }
                               }
@@ -7575,35 +7403,40 @@
                     },
                     "path-type": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                       "dev": true,
                       "requires": {
-                        "graceful-fs": "4.1.4",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                       },
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
                           "dev": true
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                           "dev": true
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                           "dev": true,
                           "requires": {
-                            "pinkie": "2.0.4"
+                            "pinkie": "^2.0.0"
                           },
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
                               "dev": true
                             }
                           }
@@ -7616,116 +7449,130 @@
             },
             "require-main-filename": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
               "dev": true
             }
           }
         },
         "yargs": {
           "version": "4.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "lodash.assign": "4.0.9",
-            "os-locale": "1.4.0",
-            "pkg-conf": "1.1.3",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "1.0.0",
-            "string-width": "1.0.1",
-            "window-size": "0.2.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "2.4.0"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "lodash.assign": "^4.0.3",
+            "os-locale": "^1.4.0",
+            "pkg-conf": "^1.1.2",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^1.0.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^2.4.0"
           },
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
               "dev": true
             },
             "cliui": {
               "version": "3.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
               "requires": {
-                "string-width": "1.0.1",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.0.0"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
               },
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "2.0.0"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
                       "dev": true
                     }
                   }
                 },
                 "wrap-ansi": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-fTD4+HP5pbvDpk2ryNF34HGuQm8=",
                   "dev": true,
                   "requires": {
-                    "string-width": "1.0.1"
+                    "string-width": "^1.0.1"
                   }
                 }
               }
             },
             "decamelize": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
               "dev": true
             },
             "lodash.assign": {
               "version": "4.0.9",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Cgcx2TWQ3dm6RYn61lqvbuCSF+M=",
               "dev": true,
               "requires": {
-                "lodash.keys": "4.0.7",
-                "lodash.rest": "4.0.3"
+                "lodash.keys": "^4.0.0",
+                "lodash.rest": "^4.0.0"
               },
               "dependencies": {
                 "lodash.keys": {
                   "version": "4.0.7",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-MOGzvZjlTWoGEZkYEmhba8R8tjs=",
                   "dev": true
                 },
                 "lodash.rest": {
                   "version": "4.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-TBwyxAAoCHJQ+r9w1C4BUVSPSMU=",
                   "dev": true
                 }
               }
             },
             "os-locale": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
               "dev": true,
               "requires": {
-                "lcid": "1.0.0"
+                "lcid": "^1.0.0"
               },
               "dependencies": {
                 "lcid": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                   "dev": true,
                   "requires": {
-                    "invert-kv": "1.0.0"
+                    "invert-kv": "^1.0.0"
                   },
                   "dependencies": {
                     "invert-kv": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
                       "dev": true
                     }
                   }
@@ -7734,51 +7581,57 @@
             },
             "pkg-conf": {
               "version": "1.1.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
               "dev": true,
               "requires": {
-                "find-up": "1.1.2",
-                "load-json-file": "1.1.0",
-                "object-assign": "4.1.0",
-                "symbol": "0.2.3"
+                "find-up": "^1.0.0",
+                "load-json-file": "^1.1.0",
+                "object-assign": "^4.0.1",
+                "symbol": "^0.2.1"
               },
               "dependencies": {
                 "load-json-file": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.4",
-                    "parse-json": "2.2.0",
-                    "pify": "2.3.0",
-                    "pinkie-promise": "2.0.1",
-                    "strip-bom": "2.0.0"
+                    "graceful-fs": "^4.1.2",
+                    "parse-json": "^2.2.0",
+                    "pify": "^2.0.0",
+                    "pinkie-promise": "^2.0.0",
+                    "strip-bom": "^2.0.0"
                   },
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.4",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
                       "dev": true
                     },
                     "parse-json": {
                       "version": "2.2.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                       "dev": true,
                       "requires": {
-                        "error-ex": "1.3.0"
+                        "error-ex": "^1.2.0"
                       },
                       "dependencies": {
                         "error-ex": {
                           "version": "1.3.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
                           "dev": true,
                           "requires": {
-                            "is-arrayish": "0.2.1"
+                            "is-arrayish": "^0.2.1"
                           },
                           "dependencies": {
                             "is-arrayish": {
                               "version": "0.2.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
                               "dev": true
                             }
                           }
@@ -7787,35 +7640,40 @@
                     },
                     "pify": {
                       "version": "2.3.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                       "dev": true
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                       "dev": true,
                       "requires": {
-                        "pinkie": "2.0.4"
+                        "pinkie": "^2.0.0"
                       },
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
                           "dev": true
                         }
                       }
                     },
                     "strip-bom": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                       "dev": true,
                       "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                       },
                       "dependencies": {
                         "is-utf8": {
                           "version": "0.2.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
                           "dev": true
                         }
                       }
@@ -7824,71 +7682,80 @@
                 },
                 "object-assign": {
                   "version": "4.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
                   "dev": true
                 },
                 "symbol": {
                   "version": "0.2.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=",
                   "dev": true
                 }
               }
             },
             "read-pkg-up": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
               "dev": true,
               "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
               },
               "dependencies": {
                 "read-pkg": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                   "dev": true,
                   "requires": {
-                    "load-json-file": "1.1.0",
-                    "normalize-package-data": "2.3.5",
-                    "path-type": "1.1.0"
+                    "load-json-file": "^1.0.0",
+                    "normalize-package-data": "^2.3.2",
+                    "path-type": "^1.0.0"
                   },
                   "dependencies": {
                     "load-json-file": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                       "dev": true,
                       "requires": {
-                        "graceful-fs": "4.1.4",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                       },
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
                           "dev": true
                         },
                         "parse-json": {
                           "version": "2.2.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                           "dev": true,
                           "requires": {
-                            "error-ex": "1.3.0"
+                            "error-ex": "^1.2.0"
                           },
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
                               "dev": true,
                               "requires": {
-                                "is-arrayish": "0.2.1"
+                                "is-arrayish": "^0.2.1"
                               },
                               "dependencies": {
                                 "is-arrayish": {
                                   "version": "0.2.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
                                   "dev": true
                                 }
                               }
@@ -7897,35 +7764,40 @@
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                           "dev": true
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                           "dev": true,
                           "requires": {
-                            "pinkie": "2.0.4"
+                            "pinkie": "^2.0.0"
                           },
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
                               "dev": true
                             }
                           }
                         },
                         "strip-bom": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                           "dev": true,
                           "requires": {
-                            "is-utf8": "0.2.1"
+                            "is-utf8": "^0.2.0"
                           },
                           "dependencies": {
                             "is-utf8": {
                               "version": "0.2.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
                               "dev": true
                             }
                           }
@@ -7934,81 +7806,92 @@
                     },
                     "normalize-package-data": {
                       "version": "2.3.5",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
                       "dev": true,
                       "requires": {
-                        "hosted-git-info": "2.1.5",
-                        "is-builtin-module": "1.0.0",
-                        "semver": "5.1.0",
-                        "validate-npm-package-license": "3.0.1"
+                        "hosted-git-info": "^2.1.4",
+                        "is-builtin-module": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
                       },
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.5",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
                           "dev": true
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                           "dev": true,
                           "requires": {
-                            "builtin-modules": "1.1.1"
+                            "builtin-modules": "^1.0.0"
                           },
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
                               "dev": true
                             }
                           }
                         },
                         "semver": {
                           "version": "5.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
                           "dev": true
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
                           "dev": true,
                           "requires": {
-                            "spdx-correct": "1.0.2",
-                            "spdx-expression-parse": "1.0.2"
+                            "spdx-correct": "~1.0.0",
+                            "spdx-expression-parse": "~1.0.0"
                           },
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                               "dev": true,
                               "requires": {
-                                "spdx-license-ids": "1.2.1"
+                                "spdx-license-ids": "^1.0.2"
                               },
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM=",
                                   "dev": true
                                 }
                               }
                             },
                             "spdx-expression-parse": {
                               "version": "1.0.2",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
                               "dev": true,
                               "requires": {
-                                "spdx-exceptions": "1.0.4",
-                                "spdx-license-ids": "1.2.1"
+                                "spdx-exceptions": "^1.0.4",
+                                "spdx-license-ids": "^1.0.0"
                               },
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.4",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
                                   "dev": true
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM=",
                                   "dev": true
                                 }
                               }
@@ -8019,35 +7902,40 @@
                     },
                     "path-type": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                       "dev": true,
                       "requires": {
-                        "graceful-fs": "4.1.4",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                       },
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
                           "dev": true
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                           "dev": true
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                           "dev": true,
                           "requires": {
-                            "pinkie": "2.0.4"
+                            "pinkie": "^2.0.0"
                           },
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
                               "dev": true
                             }
                           }
@@ -8060,65 +7948,74 @@
             },
             "require-main-filename": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
               "dev": true
             },
             "set-blocking": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-zV5dk4BI3xrJLf6S4fFq3WVvXsU=",
               "dev": true
             },
             "string-width": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.0.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               },
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
                   "dev": true,
                   "requires": {
-                    "number-is-nan": "1.0.0"
+                    "number-is-nan": "^1.0.0"
                   },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
                       "dev": true
                     }
                   }
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
                   "requires": {
-                    "number-is-nan": "1.0.0"
+                    "number-is-nan": "^1.0.0"
                   },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
                       "dev": true
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "2.0.0"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
                       "dev": true
                     }
                   }
@@ -8127,26 +8024,30 @@
             },
             "window-size": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
               "dev": true
             },
             "y18n": {
               "version": "3.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
               "dev": true
             },
             "yargs-parser": {
               "version": "2.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-HzZ9ycbPpWYLaXEjDzsnf8Xjrco=",
               "dev": true,
               "requires": {
-                "camelcase": "2.1.1",
-                "lodash.assign": "4.0.9"
+                "camelcase": "^2.1.1",
+                "lodash.assign": "^4.0.6"
               },
               "dependencies": {
                 "camelcase": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
                   "dev": true
                 }
               }
@@ -8171,8 +8072,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "observable-to-promise": {
@@ -8181,8 +8082,8 @@
       "integrity": "sha1-KK/nFkUwjy1B1x9HrT/s4aN35Ss=",
       "dev": true,
       "requires": {
-        "is-observable": "0.2.0",
-        "symbol-observable": "0.2.4"
+        "is-observable": "^0.2.0",
+        "symbol-observable": "^0.2.2"
       }
     },
     "on-finished": {
@@ -8198,7 +8099,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -8211,8 +8112,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -8228,7 +8129,7 @@
       "integrity": "sha1-6bgR4AbxwPVIAvKClb/Ilw+Nz70=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1"
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "object-assign": {
@@ -8244,9 +8145,9 @@
       "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
       "requires": {
-        "end-of-stream": "0.1.5",
-        "sequencify": "0.0.7",
-        "stream-consume": "0.1.0"
+        "end-of-stream": "~0.1.5",
+        "sequencify": "~0.0.7",
+        "stream-consume": "~0.1.0"
       }
     },
     "ordered-read-streams": {
@@ -8265,7 +8166,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "os-shim": {
@@ -8283,8 +8184,26 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "p-cancelable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-timeout": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "package-hash": {
@@ -8293,7 +8212,7 @@
       "integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
       "dev": true,
       "requires": {
-        "md5-hex": "1.3.0"
+        "md5-hex": "^1.3.0"
       }
     },
     "package-json": {
@@ -8301,8 +8220,8 @@
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
       "integrity": "sha1-yOysCUInzfdqMWh07QXifMk5oOA=",
       "requires": {
-        "got": "3.3.1",
-        "registry-url": "3.1.0"
+        "got": "^3.2.0",
+        "registry-url": "^3.0.0"
       },
       "dependencies": {
         "got": {
@@ -8310,16 +8229,16 @@
           "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
           "integrity": "sha1-5dDtSvVfw+701WAHdp2YGSvLLso=",
           "requires": {
-            "duplexify": "3.5.0",
-            "infinity-agent": "2.0.3",
-            "is-redirect": "1.0.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.0",
-            "nested-error-stacks": "1.0.2",
-            "object-assign": "3.0.0",
-            "prepend-http": "1.0.4",
-            "read-all-stream": "3.1.0",
-            "timed-out": "2.0.0"
+            "duplexify": "^3.2.0",
+            "infinity-agent": "^2.0.0",
+            "is-redirect": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "nested-error-stacks": "^1.0.0",
+            "object-assign": "^3.0.0",
+            "prepend-http": "^1.0.0",
+            "read-all-stream": "^3.0.0",
+            "timed-out": "^2.0.0"
           }
         },
         "timed-out": {
@@ -8334,9 +8253,9 @@
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
       "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
       "requires": {
-        "is-absolute": "0.2.6",
-        "map-cache": "0.2.2",
-        "path-root": "0.1.1"
+        "is-absolute": "^0.2.3",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
       }
     },
     "parse-glob": {
@@ -8344,10 +8263,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -8355,7 +8274,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-ms": {
@@ -8379,7 +8298,7 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -8402,7 +8321,7 @@
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "requires": {
-        "path-root-regex": "0.1.2"
+        "path-root-regex": "^0.1.0"
       }
     },
     "path-root-regex": {
@@ -8415,9 +8334,9 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pause-stream": {
@@ -8425,7 +8344,7 @@
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3"
       }
     },
     "performance-now": {
@@ -8449,7 +8368,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-conf": {
@@ -8458,10 +8377,10 @@
       "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "load-json-file": "1.1.0",
-        "object-assign": "4.1.1",
-        "symbol": "0.2.3"
+        "find-up": "^1.0.0",
+        "load-json-file": "^1.1.0",
+        "object-assign": "^4.0.1",
+        "symbol": "^0.2.1"
       },
       "dependencies": {
         "object-assign": {
@@ -8478,7 +8397,7 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "plexer": {
@@ -8486,7 +8405,7 @@
       "resolved": "https://registry.npmjs.org/plexer/-/plexer-0.0.3.tgz",
       "integrity": "sha1-M00dfNYjJGVBfppmNkkB8pIw9TE=",
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "^1.0.26-2"
       },
       "dependencies": {
         "isarray": {
@@ -8499,10 +8418,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -8517,7 +8436,7 @@
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "requires": {
-        "irregular-plurals": "1.2.0"
+        "irregular-plurals": "^1.0.0"
       }
     },
     "power-assert-context-formatter": {
@@ -8526,8 +8445,8 @@
       "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
-        "power-assert-context-traversal": "1.1.1"
+        "core-js": "^2.0.0",
+        "power-assert-context-traversal": "^1.1.1"
       }
     },
     "power-assert-context-reducer-ast": {
@@ -8536,11 +8455,11 @@
       "integrity": "sha1-SEqZ4m9Jc/+IMuXFzHVnAuYJQXQ=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13",
-        "acorn-es7-plugin": "1.1.7",
-        "core-js": "2.4.1",
-        "espurify": "1.7.0",
-        "estraverse": "4.2.0"
+        "acorn": "^4.0.0",
+        "acorn-es7-plugin": "^1.0.12",
+        "core-js": "^2.0.0",
+        "espurify": "^1.6.0",
+        "estraverse": "^4.2.0"
       }
     },
     "power-assert-context-traversal": {
@@ -8549,8 +8468,8 @@
       "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
-        "estraverse": "4.2.0"
+        "core-js": "^2.0.0",
+        "estraverse": "^4.1.0"
       }
     },
     "power-assert-formatter": {
@@ -8559,13 +8478,13 @@
       "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
-        "power-assert-context-formatter": "1.1.1",
-        "power-assert-context-reducer-ast": "1.1.2",
-        "power-assert-renderer-assertion": "1.1.1",
-        "power-assert-renderer-comparison": "1.1.1",
-        "power-assert-renderer-diagram": "1.1.2",
-        "power-assert-renderer-file": "1.1.1"
+        "core-js": "^2.0.0",
+        "power-assert-context-formatter": "^1.0.7",
+        "power-assert-context-reducer-ast": "^1.0.7",
+        "power-assert-renderer-assertion": "^1.0.7",
+        "power-assert-renderer-comparison": "^1.0.7",
+        "power-assert-renderer-diagram": "^1.0.7",
+        "power-assert-renderer-file": "^1.0.7"
       }
     },
     "power-assert-renderer-assertion": {
@@ -8574,8 +8493,8 @@
       "integrity": "sha1-y/wOd+AIao+Wrz8djme57n4ozpg=",
       "dev": true,
       "requires": {
-        "power-assert-renderer-base": "1.1.1",
-        "power-assert-util-string-width": "1.1.1"
+        "power-assert-renderer-base": "^1.1.1",
+        "power-assert-util-string-width": "^1.1.1"
       }
     },
     "power-assert-renderer-base": {
@@ -8590,11 +8509,11 @@
       "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
-        "diff-match-patch": "1.0.0",
-        "power-assert-renderer-base": "1.1.1",
-        "stringifier": "1.3.0",
-        "type-name": "2.0.2"
+        "core-js": "^2.0.0",
+        "diff-match-patch": "^1.0.0",
+        "power-assert-renderer-base": "^1.1.1",
+        "stringifier": "^1.3.0",
+        "type-name": "^2.0.1"
       }
     },
     "power-assert-renderer-diagram": {
@@ -8603,10 +8522,10 @@
       "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
-        "power-assert-renderer-base": "1.1.1",
-        "power-assert-util-string-width": "1.1.1",
-        "stringifier": "1.3.0"
+        "core-js": "^2.0.0",
+        "power-assert-renderer-base": "^1.1.1",
+        "power-assert-util-string-width": "^1.1.1",
+        "stringifier": "^1.3.0"
       }
     },
     "power-assert-renderer-file": {
@@ -8615,7 +8534,7 @@
       "integrity": "sha1-o34rvReMys0E5427eckv40kzxec=",
       "dev": true,
       "requires": {
-        "power-assert-renderer-base": "1.1.1"
+        "power-assert-renderer-base": "^1.1.1"
       }
     },
     "power-assert-renderer-succinct": {
@@ -8624,8 +8543,8 @@
       "integrity": "sha1-wqRosjgiq9b4Diq6UyI0ewnfR24=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
-        "power-assert-renderer-diagram": "1.1.2"
+        "core-js": "^2.0.0",
+        "power-assert-renderer-diagram": "^1.1.1"
       }
     },
     "power-assert-renderers": {
@@ -8634,11 +8553,11 @@
       "integrity": "sha1-agnhwB4Oz4+qZ0lAGn2isOBZgQc=",
       "dev": true,
       "requires": {
-        "power-assert-renderer-assertion": "1.1.1",
-        "power-assert-renderer-comparison": "1.1.1",
-        "power-assert-renderer-diagram": "1.1.2",
-        "power-assert-renderer-file": "1.1.1",
-        "power-assert-renderer-succinct": "1.1.1"
+        "power-assert-renderer-assertion": "^1.0.0",
+        "power-assert-renderer-comparison": "^1.0.0",
+        "power-assert-renderer-diagram": "^1.0.0",
+        "power-assert-renderer-file": "^1.0.0",
+        "power-assert-renderer-succinct": "^1.0.0"
       }
     },
     "power-assert-util-string-width": {
@@ -8647,7 +8566,7 @@
       "integrity": "sha1-vmWet5N/3S5smncmjar2S9W3xZI=",
       "dev": true,
       "requires": {
-        "eastasianwidth": "0.1.1"
+        "eastasianwidth": "^0.1.1"
       }
     },
     "prepend-http": {
@@ -8671,9 +8590,9 @@
       "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2",
-        "parse-ms": "1.0.1",
-        "plur": "1.0.0"
+        "is-finite": "^1.0.1",
+        "parse-ms": "^1.0.0",
+        "plur": "^1.0.0"
       },
       "dependencies": {
         "plur": {
@@ -8722,8 +8641,8 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -8731,7 +8650,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -8739,7 +8658,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -8749,7 +8668,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -8776,10 +8695,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.4",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
     },
     "read-all-stream": {
@@ -8787,8 +8706,8 @@
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "requires": {
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.2.11"
+        "pinkie-promise": "^2.0.0",
+        "readable-stream": "^2.0.0"
       }
     },
     "read-pkg": {
@@ -8796,9 +8715,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.3.8",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -8806,8 +8725,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -8815,13 +8734,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
       "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.0.1",
-        "string_decoder": "1.0.2",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.0.1",
+        "string_decoder": "~1.0.0",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -8831,10 +8750,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.2.11",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "readline2": {
@@ -8842,8 +8761,8 @@
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       },
       "dependencies": {
@@ -8859,7 +8778,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "1.3.3"
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -8867,8 +8786,8 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "regenerate": {
@@ -8889,9 +8808,9 @@
       "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "private": "0.1.7"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -8899,8 +8818,8 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "^0.1.3",
+        "is-primitive": "^2.0.0"
       }
     },
     "regexpu-core": {
@@ -8909,9 +8828,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.2",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "registry-auth-token": {
@@ -8919,8 +8838,8 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "requires": {
-        "rc": "1.2.1",
-        "safe-buffer": "5.0.1"
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
@@ -8928,7 +8847,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
-        "rc": "1.2.1"
+        "rc": "^1.0.1"
       }
     },
     "regjsgen": {
@@ -8943,7 +8862,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -8974,7 +8893,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "replace-ext": {
@@ -8988,28 +8907,28 @@
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.15",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.0.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.0.1"
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.1.1",
+        "har-validator": "~4.2.1",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "oauth-sign": "~0.8.1",
+        "performance-now": "^0.2.0",
+        "qs": "~6.4.0",
+        "safe-buffer": "^5.0.1",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.0.0"
       },
       "dependencies": {
         "qs": {
@@ -9048,7 +8967,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-cwd": {
@@ -9057,7 +8976,7 @@
       "integrity": "sha1-Tq7qQe0EDRcCRX32SkKysH0kb58=",
       "dev": true,
       "requires": {
-        "resolve-from": "2.0.0"
+        "resolve-from": "^2.0.0"
       }
     },
     "resolve-dir": {
@@ -9065,8 +8984,8 @@
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
       "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
+        "expand-tilde": "^1.2.2",
+        "global-modules": "^0.2.3"
       }
     },
     "resolve-from": {
@@ -9080,8 +8999,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "rimraf": {
@@ -9089,7 +9008,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "roolz": {
@@ -9097,8 +9016,8 @@
       "resolved": "https://registry.npmjs.org/roolz/-/roolz-1.0.2.tgz",
       "integrity": "sha1-9GScCTA2bsSxs12cbFr9ofHpGM8=",
       "requires": {
-        "drip": "1.4.0",
-        "lodash": "3.10.1",
+        "drip": "^1.4.0",
+        "lodash": "^3.10.1",
         "string-sub": "0.0.1"
       }
     },
@@ -9107,7 +9026,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "run-sequence": {
@@ -9115,8 +9034,8 @@
       "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
       "integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
       "requires": {
-        "chalk": "1.1.3",
-        "gulp-util": "3.0.8"
+        "chalk": "*",
+        "gulp-util": "*"
       }
     },
     "rx-lite": {
@@ -9141,10 +9060,10 @@
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^7.0.0"
       },
       "dependencies": {
         "lodash": {
@@ -9166,8 +9085,8 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.1.9",
-        "source-map": "0.4.4"
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
       },
       "dependencies": {
         "source-map": {
@@ -9176,7 +9095,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -9191,7 +9110,7 @@
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "5.3.0"
+        "semver": "^5.0.3"
       },
       "dependencies": {
         "semver": {
@@ -9223,7 +9142,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -9251,7 +9170,7 @@
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": "0.10.3"
+        "util": ">=0.10.3 <1"
       }
     },
     "slash": {
@@ -9277,7 +9196,7 @@
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "sort-keys": {
@@ -9286,7 +9205,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "source-map": {
@@ -9294,7 +9213,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
       "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "source-map-support": {
@@ -9303,7 +9222,7 @@
       "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.6"
+        "source-map": "^0.5.6"
       },
       "dependencies": {
         "source-map": {
@@ -9324,8 +9243,8 @@
       "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
       "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
       "requires": {
-        "concat-stream": "1.6.0",
-        "os-shim": "0.1.3"
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
       }
     },
     "spdx-correct": {
@@ -9333,7 +9252,7 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -9351,7 +9270,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "sprintf-js": {
@@ -9365,14 +9284,14 @@
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -9400,7 +9319,7 @@
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.2.11"
+        "readable-stream": "^2.0.1"
       }
     },
     "stream-combiner": {
@@ -9408,7 +9327,7 @@
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "~0.1.1"
       }
     },
     "stream-consume": {
@@ -9431,9 +9350,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -9441,7 +9360,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
       "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
       "requires": {
-        "safe-buffer": "5.0.1"
+        "safe-buffer": "~5.0.1"
       }
     },
     "stringifier": {
@@ -9450,9 +9369,9 @@
       "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
-        "traverse": "0.6.6",
-        "type-name": "2.0.2"
+        "core-js": "^2.0.0",
+        "traverse": "^0.6.6",
+        "type-name": "^2.0.1"
       }
     },
     "stringify-object": {
@@ -9460,8 +9379,8 @@
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-2.4.0.tgz",
       "integrity": "sha1-xi0RAj6yH+LZsIe+A5om3zsioJ0=",
       "requires": {
-        "is-plain-obj": "1.1.0",
-        "is-regexp": "1.0.0"
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
       }
     },
     "stringstream": {
@@ -9475,7 +9394,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -9483,7 +9402,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-indent": {
@@ -9491,7 +9410,7 @@
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -9522,9 +9441,9 @@
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "tea-concat": {
@@ -9537,10 +9456,10 @@
       "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
       "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
       "requires": {
-        "duplexify": "3.5.0",
-        "fork-stream": "0.0.4",
-        "merge-stream": "1.0.1",
-        "through2": "2.0.3"
+        "duplexify": "^3.5.0",
+        "fork-stream": "^0.0.4",
+        "merge-stream": "^1.0.0",
+        "through2": "^2.0.1"
       },
       "dependencies": {
         "merge-stream": {
@@ -9548,7 +9467,7 @@
           "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
           "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
           "requires": {
-            "readable-stream": "2.2.11"
+            "readable-stream": "^2.0.1"
           }
         }
       }
@@ -9575,8 +9494,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.2.11",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "tildify": {
@@ -9584,7 +9503,7 @@
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "time-require": {
@@ -9593,10 +9512,10 @@
       "integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
       "dev": true,
       "requires": {
-        "chalk": "0.4.0",
-        "date-time": "0.1.1",
-        "pretty-ms": "0.2.2",
-        "text-table": "0.2.0"
+        "chalk": "^0.4.0",
+        "date-time": "^0.1.1",
+        "pretty-ms": "^0.2.1",
+        "text-table": "^0.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9611,9 +9530,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
           }
         },
         "parse-ms": {
@@ -9628,7 +9547,7 @@
           "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
           "dev": true,
           "requires": {
-            "parse-ms": "0.1.2"
+            "parse-ms": "^0.1.0"
           }
         },
         "strip-ansi": {
@@ -9666,7 +9585,7 @@
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "traverse": {
@@ -9692,7 +9611,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.0.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -9714,7 +9633,7 @@
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.15"
+        "mime-types": "~2.1.15"
       }
     },
     "type-name": {
@@ -9734,9 +9653,9 @@
       "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
       "optional": true,
       "requires": {
-        "async": "0.2.10",
-        "optimist": "0.3.7",
-        "source-map": "0.1.43"
+        "async": "~0.2.6",
+        "optimist": "~0.3.5",
+        "source-map": "~0.1.7"
       },
       "dependencies": {
         "async": {
@@ -9751,7 +9670,7 @@
           "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
           "optional": true,
           "requires": {
-            "wordwrap": "0.0.3"
+            "wordwrap": "~0.0.2"
           }
         }
       }
@@ -9778,8 +9697,8 @@
       "integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1",
-        "os-tmpdir": "1.0.2",
+        "mkdirp": "^0.5.1",
+        "os-tmpdir": "^1.0.1",
         "uid2": "0.0.3"
       }
     },
@@ -9798,14 +9717,14 @@
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
       "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
       "requires": {
-        "boxen": "0.6.0",
-        "chalk": "1.1.3",
-        "configstore": "2.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "2.0.0",
-        "lazy-req": "1.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "2.0.0"
+        "boxen": "^0.6.0",
+        "chalk": "^1.0.0",
+        "configstore": "^2.0.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^2.0.0",
+        "lazy-req": "^1.1.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^2.0.0"
       }
     },
     "url-parse-lax": {
@@ -9813,8 +9732,13 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
     "user-home": {
       "version": "1.1.1",
@@ -9853,7 +9777,7 @@
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "requires": {
-        "user-home": "1.1.1"
+        "user-home": "^1.1.1"
       }
     },
     "validate-npm-package-license": {
@@ -9861,8 +9785,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "verror": {
@@ -9879,13 +9803,13 @@
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
       "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
       "requires": {
-        "clone": "1.0.2",
-        "clone-buffer": "1.0.0",
-        "clone-stats": "1.0.0",
-        "cloneable-readable": "1.0.0",
-        "is-stream": "1.1.0",
-        "remove-trailing-separator": "1.0.2",
-        "replace-ext": "1.0.0"
+        "clone": "^1.0.0",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "is-stream": "^1.1.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
       }
     },
     "vinyl-fs": {
@@ -9893,14 +9817,14 @@
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "requires": {
-        "defaults": "1.0.3",
-        "glob-stream": "3.1.18",
-        "glob-watcher": "0.0.6",
-        "graceful-fs": "3.0.11",
-        "mkdirp": "0.5.1",
-        "strip-bom": "1.0.0",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
+        "defaults": "^1.0.0",
+        "glob-stream": "^3.1.5",
+        "glob-watcher": "^0.0.6",
+        "graceful-fs": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "strip-bom": "^1.0.0",
+        "through2": "^0.6.1",
+        "vinyl": "^0.4.0"
       },
       "dependencies": {
         "clone": {
@@ -9918,7 +9842,7 @@
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "requires": {
-            "natives": "1.1.0"
+            "natives": "^1.1.0"
           }
         },
         "isarray": {
@@ -9931,10 +9855,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -9947,8 +9871,8 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
           "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
           "requires": {
-            "first-chunk-stream": "1.0.0",
-            "is-utf8": "0.2.1"
+            "first-chunk-stream": "^1.0.0",
+            "is-utf8": "^0.2.0"
           }
         },
         "through2": {
@@ -9956,8 +9880,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         },
         "vinyl": {
@@ -9965,8 +9889,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
+            "clone": "^0.2.0",
+            "clone-stats": "^0.0.1"
           }
         }
       }
@@ -9976,7 +9900,7 @@
       "resolved": "https://registry.npmjs.org/vinyl-paths/-/vinyl-paths-1.0.0.tgz",
       "integrity": "sha1-/Ccq2pFbTD6CZM+wbeddPOB8ip4=",
       "requires": {
-        "through2": "0.6.5"
+        "through2": "^0.6.3"
       },
       "dependencies": {
         "isarray": {
@@ -9989,10 +9913,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -10005,8 +9929,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -10017,7 +9941,7 @@
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.6"
+        "source-map": "^0.5.1"
       },
       "dependencies": {
         "source-map": {
@@ -10033,7 +9957,7 @@
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
       "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
       "requires": {
-        "websocket-extensions": "0.1.1"
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
@@ -10046,7 +9970,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -10061,7 +9985,7 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       }
     },
     "widest-line": {
@@ -10069,7 +9993,7 @@
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       }
     },
     "wordwrap": {
@@ -10083,8 +10007,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -10097,9 +10021,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
       "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
       }
     },
     "write-json-file": {
@@ -10108,13 +10032,13 @@
       "integrity": "sha1-LV3+lqvDyIkFfJOXGqQAXvtUgTQ=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "sort-keys": "1.1.2",
-        "write-file-atomic": "1.3.4"
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "sort-keys": "^1.1.1",
+        "write-file-atomic": "^1.1.2"
       },
       "dependencies": {
         "object-assign": {
@@ -10131,7 +10055,7 @@
       "integrity": "sha1-rriqnU14jh2JPfsIVJaLVDqRn1c=",
       "dev": true,
       "requires": {
-        "write-json-file": "1.2.0"
+        "write-json-file": "^1.1.0"
       }
     },
     "xdg-basedir": {
@@ -10139,7 +10063,7 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
       "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "xml2js": {
@@ -10147,8 +10071,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
       "requires": {
-        "sax": "1.2.2",
-        "xmlbuilder": "4.2.1"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "^4.1.0"
       }
     },
     "xmlbuilder": {
@@ -10156,7 +10080,7 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.0.0"
       },
       "dependencies": {
         "lodash": {
@@ -10188,19 +10112,19 @@
       "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "5.0.0"
+        "camelcase": "^3.0.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.2",
+        "which-module": "^1.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^5.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -10217,7 +10141,7 @@
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0"
+        "camelcase": "^3.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -10233,7 +10157,7 @@
       "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.2.tgz",
       "integrity": "sha1-FMsZCD4eJacAksFYiqvg9OTdTYg=",
       "requires": {
-        "buffer-crc32": "0.2.13"
+        "buffer-crc32": "~0.2.3"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,15 +5,15 @@
   "requires": true,
   "dependencies": {
     "abbrev": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "acorn": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
       "dev": true
     },
     "acorn-es7-plugin": {
@@ -50,6 +50,14 @@
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
     },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -60,15 +68,119 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+    },
     "anymatch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "arrify": "^1.0.0",
-        "micromatch": "^2.1.5"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true,
+          "optional": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
+        }
       }
     },
     "applause": {
@@ -82,9 +194,9 @@
       }
     },
     "aproba": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
     "archy": {
@@ -93,9 +205,9 @@
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
     },
     "are-we-there-yet": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "requires": {
         "delegates": "^1.0.0",
@@ -103,20 +215,17 @@
       }
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "requires": {
-        "arr-flatten": "^1.0.1"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-exclude": {
       "version": "1.0.0",
@@ -125,19 +234,34 @@
       "dev": true
     },
     "arr-flatten": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-      "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-differ": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
     },
+    "array-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+    },
+    "array-slice": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
     },
     "array-union": {
       "version": "1.0.2",
@@ -153,9 +277,9 @@
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "arrify": {
       "version": "1.0.1",
@@ -180,6 +304,11 @@
       "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
       "dev": true
     },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+    },
     "async": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
@@ -203,6 +332,11 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "atob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
     },
     "ava": {
       "version": "0.15.2",
@@ -284,6 +418,15 @@
         "update-notifier": "^0.7.0"
       },
       "dependencies": {
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
         "boxen": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.5.1.tgz",
@@ -363,89 +506,89 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
       "dev": true
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.0",
+        "chalk": "^1.1.3",
         "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
-      "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "babel-generator": "^6.25.0",
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
         "babel-helpers": "^6.24.1",
         "babel-messages": "^6.23.0",
-        "babel-register": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.25.0",
-        "babel-traverse": "^6.25.0",
-        "babel-types": "^6.25.0",
-        "babylon": "^6.17.2",
-        "convert-source-map": "^1.1.0",
-        "debug": "^2.1.1",
-        "json5": "^0.5.0",
-        "lodash": "^4.2.0",
-        "minimatch": "^3.0.2",
-        "path-is-absolute": "^1.0.0",
-        "private": "^0.1.6",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
         "slash": "^1.0.0",
-        "source-map": "^0.5.0"
+        "source-map": "^0.5.7"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         },
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
     },
     "babel-generator": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-      "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
         "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.25.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
         "detect-indent": "^4.0.0",
         "jsesc": "^1.3.0",
-        "lodash": "^4.2.0",
-        "source-map": "^0.5.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
         "trim-right": "^1.0.1"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         },
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
@@ -485,21 +628,21 @@
       }
     },
     "babel-helper-define-map": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
-      "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
         "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1",
-        "lodash": "^4.2.0"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         }
       }
@@ -571,20 +714,20 @@
       }
     },
     "babel-helper-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1",
-        "lodash": "^4.2.0"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         }
       }
@@ -661,9 +804,9 @@
       "dev": true
     },
     "babel-plugin-espower": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.3.2.tgz",
-      "integrity": "sha1-VRa4/NsmyfDh2BYHSfbkxl5xJx4=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.4.0.tgz",
+      "integrity": "sha512-/+SRpy7pKgTI28oEHfn1wkuM5QFAdRq8WNsOOih1dVrdV6A/WbNbRZyl0eX5eyDgtb0lOE27PeDFuCX2j8OxVg==",
       "dev": true,
       "requires": {
         "babel-generator": "^6.1.0",
@@ -789,22 +932,22 @@
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-      "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1",
-        "lodash": "^4.2.0"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         }
       }
@@ -896,15 +1039,15 @@
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1024,22 +1167,22 @@
       }
     },
     "babel-plugin-transform-object-rest-spread": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
-      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "dev": true,
       "requires": {
         "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "^6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-      "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.9.11"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-runtime": {
@@ -1119,108 +1262,108 @@
       }
     },
     "babel-register": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "core-js": "^2.4.0",
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
         "home-or-tmp": "^2.0.0",
-        "lodash": "^4.2.0",
+        "lodash": "^4.17.4",
         "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.2"
+        "source-map-support": "^0.4.15"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         }
       }
     },
     "babel-runtime": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
         "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.10.0"
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-      "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.25.0",
-        "babel-types": "^6.25.0",
-        "babylon": "^6.17.2",
-        "lodash": "^4.2.0"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         }
       }
     },
     "babel-traverse": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-      "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
+        "babel-code-frame": "^6.26.0",
         "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.25.0",
-        "babylon": "^6.17.2",
-        "debug": "^2.2.0",
-        "globals": "^9.0.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.2.0"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         }
       }
     },
     "babel-types": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
+        "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
-        "lodash": "^4.2.0",
-        "to-fast-properties": "^1.0.1"
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         }
       }
     },
     "babylon": {
-      "version": "6.17.3",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
-      "integrity": "sha512-mq0x3HCAGGmQyZXviOVe5TRsw37Ijy3D43jCqt/9WVf+onx2dUgW3PosnqCbScAFhRO9DGs8nxoMzU0iiosMqQ==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "balanced-match": {
@@ -1228,10 +1371,60 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1244,9 +1437,9 @@
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
     },
     "binary-extensions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
-      "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true,
       "optional": true
     },
@@ -1269,9 +1462,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "body-parser": {
       "version": "1.14.2",
@@ -1348,22 +1541,39 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "buf-compare": {
@@ -1383,6 +1593,11 @@
       "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U=",
       "dev": true
     },
+    "buffer-from": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -1392,6 +1607,22 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
       "integrity": "sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg="
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
     },
     "caching-transform": {
       "version": "1.0.1",
@@ -1494,13 +1725,53 @@
         "is-glob": "^2.0.0",
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true,
+          "optional": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
       }
     },
     "ci-info": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
-      "integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
       "dev": true
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
     },
     "clean-yaml-object": {
       "version": "0.1.0",
@@ -1564,9 +1835,9 @@
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
       "version": "3.2.0",
@@ -1580,9 +1851,9 @@
       }
     },
     "clone": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
     },
     "clone-buffer": {
       "version": "1.0.0",
@@ -1595,13 +1866,13 @@
       "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
     },
     "cloneable-readable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
-      "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+      "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "requires": {
         "inherits": "^2.0.1",
-        "process-nextick-args": "^1.0.6",
-        "through2": "^2.0.1"
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
       }
     },
     "co": {
@@ -1642,14 +1913,28 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "coffee-script": {
-      "version": "1.12.6",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.6.tgz",
-      "integrity": "sha1-KFo/cRVokGUGTWv570Vy22ZpXL8="
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -1672,33 +1957,39 @@
       "resolved": "https://registry.npmjs.org/compass-mixins/-/compass-mixins-0.12.10.tgz",
       "integrity": "sha1-zZ8V+CnE6WDMQ7sibwSbKL65nUE="
     },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
+        "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
       }
     },
     "concat-with-sourcemaps": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
-      "integrity": "sha1-9Vs74q60dgGxCi1SWcz7cP0vHdY=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
       "requires": {
-        "source-map": "^0.5.1"
+        "source-map": "^0.6.1"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -1762,14 +2053,14 @@
       }
     },
     "content-type": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-bootstrap-2-to-3": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/convert-bootstrap-2-to-3/-/convert-bootstrap-2-to-3-1.0.3.tgz",
-      "integrity": "sha1-dn6Z5pGLLgOr2SawCe8+ckHSnts=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/convert-bootstrap-2-to-3/-/convert-bootstrap-2-to-3-1.0.4.tgz",
+      "integrity": "sha512-hs6uQNMSyeRao5G3z4gu+lYVLXC2zt8FDSN2VilUq+lWQLJKgIRDrHufhjQ7Xpy8ZsWQ3CSOBJG93so7BXOYDQ==",
       "requires": {
         "async": "^0.7.0",
         "cli": "^0.4.5",
@@ -1792,9 +2083,14 @@
       }
     },
     "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-assert": {
       "version": "0.2.1",
@@ -1807,9 +2103,9 @@
       }
     },
     "core-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
       "dev": true
     },
     "core-util-is": {
@@ -1906,14 +2202,14 @@
       "dev": true
     },
     "dateformat": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-      "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -1922,6 +2218,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -1947,9 +2248,9 @@
       "dev": true
     },
     "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "defaults": {
       "version": "1.0.3",
@@ -1957,6 +2258,50 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "requires": {
         "clone": "^1.0.2"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+        }
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
       }
     },
     "del": {
@@ -2015,9 +2360,9 @@
       "dev": true
     },
     "depd": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "deprecated": {
       "version": "0.0.1",
@@ -2025,12 +2370,9 @@
       "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk="
     },
     "detect-file": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
-      "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-      "requires": {
-        "fs-exists-sync": "^0.1.0"
-      }
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -2047,9 +2389,9 @@
       "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
     },
     "diff-match-patch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
-      "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.1.tgz",
+      "integrity": "sha512-A0QEhr4PxGUMEtKxd6X+JLnOTFd3BfIPSDpsc4dMvj+CbSaErDwTpoTo/nFJDMSrjxLW4BiNq+FbNisAAHhWeQ==",
       "dev": true
     },
     "dot-prop": {
@@ -2110,32 +2452,14 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "duplexify": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
-      "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
-        "end-of-stream": "1.0.0",
+        "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
-      },
-      "dependencies": {
-        "end-of-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-          "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
-          "requires": {
-            "once": "~1.3.0"
-          }
-        },
-        "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "requires": {
-            "wrappy": "1"
-          }
-        }
       }
     },
     "each-async": {
@@ -2148,9 +2472,9 @@
       }
     },
     "eastasianwidth": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.1.1.tgz",
-      "integrity": "sha1-RNZW3p2kFWlEZzNTZfsxR7hXK3w=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
     "ecc-jsbn": {
@@ -2188,27 +2512,17 @@
       }
     },
     "end-of-stream": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-      "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "~1.3.0"
-      },
-      "dependencies": {
-        "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "requires": {
-            "wrappy": "1"
-          }
-        }
+        "once": "^1.4.0"
       }
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -2236,22 +2550,22 @@
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
     },
     "esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "espurify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
-      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.0.tgz",
+      "integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0"
@@ -2279,7 +2593,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "requires": {
         "duplexer": "~0.1.1",
@@ -2297,27 +2611,99 @@
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
     },
     "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "fill-range": "^2.1.0"
+      },
+      "dependencies": {
+        "fill-range": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "expand-tilde": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "requires": {
-        "os-homedir": "^1.0.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "extend": {
@@ -2325,28 +2711,111 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
-    "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
       }
     },
     "extsprintf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "requires": {
-        "chalk": "^1.1.1",
+        "ansi-gray": "^0.1.1",
+        "color-support": "^1.1.3",
         "time-stamp": "^1.0.0"
       }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "faye-websocket": {
       "version": "0.7.3",
@@ -2375,18 +2844,29 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "filled-array": {
@@ -2449,16 +2929,14 @@
       }
     },
     "fined": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
-      "integrity": "sha1-WyhCS3YNdZiWC374SA3/itNmDpc=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
+      "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "requires": {
-        "expand-tilde": "^1.2.1",
-        "lodash.assignwith": "^4.0.7",
-        "lodash.isempty": "^4.2.1",
-        "lodash.isplainobject": "^4.0.4",
-        "lodash.isstring": "^4.0.1",
-        "lodash.pick": "^4.2.1",
+        "expand-tilde": "^2.0.2",
+        "is-plain-object": "^2.0.3",
+        "object.defaults": "^1.1.0",
+        "object.pick": "^1.2.0",
         "parse-filepath": "^1.0.1"
       }
     },
@@ -2468,9 +2946,9 @@
       "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
     },
     "flagged-respawn": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
-      "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
+      "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c="
     },
     "fn-name": {
       "version": "2.0.1",
@@ -2484,9 +2962,9 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "requires": {
         "for-in": "^1.0.1"
       }
@@ -2522,15 +3000,18 @@
         "samsam": "~1.1"
       }
     },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
     "from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
-    },
-    "fs-exists-sync": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
     },
     "fs-extra": {
       "version": "0.24.0",
@@ -2800,13 +3281,6 @@
         "ms": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
           "dev": true,
           "optional": true
         },
@@ -3144,6 +3618,11 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -3178,17 +3657,56 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "glob-parent": "^2.0.0",
         "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true,
+          "optional": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
       }
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true,
       "requires": {
         "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
       }
     },
     "glob-stream": {
@@ -3272,23 +3790,25 @@
       }
     },
     "global-modules": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "requires": {
-        "global-prefix": "^0.1.4",
-        "is-windows": "^0.2.0"
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
       }
     },
     "global-prefix": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "requires": {
-        "homedir-polyfill": "^1.0.0",
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
         "ini": "^1.3.4",
-        "is-windows": "^0.2.0",
-        "which": "^1.2.12"
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "globals": {
@@ -3381,9 +3901,9 @@
       }
     },
     "glogg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+      "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "requires": {
         "sparkles": "^1.0.0"
       }
@@ -3398,9 +3918,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -3414,48 +3934,32 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         }
       }
     },
     "got": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
-      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
       "requires": {
-        "create-error-class": "^3.0.1",
-        "duplexer2": "^0.1.4",
-        "is-redirect": "^1.0.0",
+        "decompress-response": "^3.2.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
         "is-retry-allowed": "^1.0.0",
         "is-stream": "^1.0.0",
+        "isurl": "^1.0.0-alpha5",
         "lowercase-keys": "^1.0.0",
-        "node-status-codes": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "parse-json": "^2.1.0",
-        "pinkie-promise": "^2.0.0",
-        "read-all-stream": "^3.0.0",
-        "readable-stream": "^2.0.5",
-        "timed-out": "^3.0.0",
-        "unzip-response": "^1.0.2",
-        "url-parse-lax": "^1.0.0"
-      },
-      "dependencies": {
-        "duplexer2": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-          "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-          "requires": {
-            "readable-stream": "^2.0.2"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        }
+        "p-cancelable": "^0.3.0",
+        "p-timeout": "^1.1.1",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "url-parse-lax": "^1.0.0",
+        "url-to-options": "^1.0.1"
       }
     },
     "graceful-fs": {
@@ -3748,7 +4252,7 @@
         },
         "event-stream": {
           "version": "3.0.20",
-          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.0.20.tgz",
+          "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.0.20.tgz",
           "integrity": "sha1-A4u7LqnqkDhbJvvBhU0LU58qvqM=",
           "requires": {
             "duplexer": "~0.1.1",
@@ -3792,9 +4296,9 @@
       }
     },
     "gulp-rename": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
-      "integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.3.0.tgz",
+      "integrity": "sha512-nEuZB7/9i0IZ8AXORTizl2QLP9tcC9uWc/s329zElBLJw1CfOhmMXBxwVlCRKjDyrWuhVP0uBKl61KeQ32TiCg=="
     },
     "gulp-replace-task": {
       "version": "0.2.3",
@@ -3847,14 +4351,14 @@
       }
     },
     "gulp-sass": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.1.0.tgz",
-      "integrity": "sha1-U9xLaKH13f5EJKtMJHZVJpqLdLc=",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.2.1.tgz",
+      "integrity": "sha512-UATbRpSDsyXCnpYSPBUEvdvtSEzksJs7/oQ0CujIpzKqKrO6vlnYwhX2UTsGrf4rNLwqlSSaM271It0uHYvJ3Q==",
       "dev": true,
       "requires": {
         "gulp-util": "^3.0",
         "lodash.clonedeep": "^4.3.2",
-        "node-sass": "^4.2.0",
+        "node-sass": "^4.8.3",
         "through2": "^2.0.0",
         "vinyl-sourcemaps-apply": "^0.2.0"
       }
@@ -3871,6 +4375,11 @@
         "vinyl": "^1.0.0"
       },
       "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+        },
         "clone-stats": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
@@ -4106,6 +4615,11 @@
         "vinyl": "^0.5.0"
       },
       "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+        },
         "clone-stats": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
@@ -4221,6 +4735,35 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
@@ -4258,9 +4801,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-      "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.1.tgz",
+      "integrity": "sha512-Ba4+0M4YvIDUUsprMjhVTU1yN9F2/LJSAl69ZpzaLT4l4j5mwTS6jqqW9Ojvj6lKz/veqPzpJBqGbXspOb533A=="
     },
     "http-errors": {
       "version": "1.3.1",
@@ -4270,6 +4813,11 @@
         "inherits": "~2.0.1",
         "statuses": "1"
       }
+    },
+    "http-parser-js": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
+      "integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc="
     },
     "http-signature": {
       "version": "1.1.1",
@@ -4332,9 +4880,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "0.12.0",
@@ -4357,21 +4905,21 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
     "interpret": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
@@ -4384,17 +4932,35 @@
       "dev": true
     },
     "irregular-plurals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.2.0.tgz",
-      "integrity": "sha1-OPKZg0uowAwwvpxVThNyaXUv86w="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
     },
     "is-absolute": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
-      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "requires": {
-        "is-relative": "^0.2.1",
-        "is-windows": "^0.2.0"
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-arrayish": {
@@ -4413,9 +4979,9 @@
       }
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -4426,23 +4992,62 @@
       }
     },
     "is-ci": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
-      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
         "ci-info": "^1.0.0"
       }
     },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true,
+      "optional": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "is-primitive": "^2.0.0"
       }
@@ -4459,9 +5064,9 @@
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -4486,11 +5091,11 @@
       "dev": true
     },
     "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "^2.1.0"
       }
     },
     "is-npm": {
@@ -4499,11 +5104,21 @@
       "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
     },
     "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-obj": {
@@ -4531,17 +5146,17 @@
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "requires": {
         "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
         "path-is-inside": "^1.0.1"
       }
@@ -4551,15 +5166,27 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true,
+      "optional": true
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true,
+      "optional": true
     },
     "is-promise": {
       "version": "2.1.0",
@@ -4578,11 +5205,11 @@
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
     "is-relative": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "requires": {
-        "is-unc-path": "^0.1.1"
+        "is-unc-path": "^1.0.0"
       }
     },
     "is-retry-allowed": {
@@ -4602,17 +5229,17 @@
       "dev": true
     },
     "is-unc-path": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "requires": {
-        "unc-path-regex": "^0.1.0"
+        "unc-path-regex": "^0.1.2"
       }
     },
     "is-url": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
-      "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true
     },
     "is-utf8": {
@@ -4621,9 +5248,9 @@
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-windows": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -4636,12 +5263,9 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "requires": {
-        "isarray": "1.0.0"
-      }
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
@@ -4659,24 +5283,24 @@
       }
     },
     "js-base64": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-      "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",
+      "integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ==",
       "dev": true
     },
     "js-tokens": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "requires": {
         "argparse": "^1.0.7",
-        "esprima": "^3.1.1"
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -4696,6 +5320,12 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
     "json-stable-stringify": {
@@ -4734,15 +5364,15 @@
       "dev": true
     },
     "jsprim": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
-        "extsprintf": "1.0.2",
+        "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
-        "verror": "1.3.6"
+        "verror": "1.10.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -4754,12 +5384,9 @@
       }
     },
     "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
     },
     "last-line-stream": {
       "version": "1.0.0",
@@ -4778,6 +5405,41 @@
         "package-json": "^2.0.0"
       },
       "dependencies": {
+        "duplexer2": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+          "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+          "requires": {
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "got": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+          "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+          "requires": {
+            "create-error-class": "^3.0.1",
+            "duplexer2": "^0.1.4",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "node-status-codes": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "parse-json": "^2.1.0",
+            "pinkie-promise": "^2.0.0",
+            "read-all-stream": "^3.0.0",
+            "readable-stream": "^2.0.5",
+            "timed-out": "^3.0.0",
+            "unzip-response": "^1.0.2",
+            "url-parse-lax": "^1.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
         "package-json": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
@@ -4790,9 +5452,14 @@
           }
         },
         "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        },
+        "timed-out": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+          "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
         }
       }
     },
@@ -4821,16 +5488,22 @@
       "integrity": "sha1-5Nc+QGAg2QfJCbyssnAKUvocfxY=",
       "dev": true
     },
+    "liferay-frontend-theme-classic-web": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/liferay-frontend-theme-classic-web/-/liferay-frontend-theme-classic-web-2.0.2.tgz",
+      "integrity": "sha1-mFrY147m7HwOX6YaFGXc76NuG1o=",
+      "dev": true
+    },
     "liferay-frontend-theme-styled": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/liferay-frontend-theme-styled/-/liferay-frontend-theme-styled-2.0.25.tgz",
-      "integrity": "sha1-paJnHqMts36+t+lJOb62+WaOEDQ=",
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/liferay-frontend-theme-styled/-/liferay-frontend-theme-styled-2.0.28.tgz",
+      "integrity": "sha1-IQx2gcjHhScwHcdk3GhS11C6Crg=",
       "dev": true
     },
     "liferay-frontend-theme-unstyled": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/liferay-frontend-theme-unstyled/-/liferay-frontend-theme-unstyled-2.1.9.tgz",
-      "integrity": "sha1-lMrDfvttc7K1kGYkC/Efs4FTVxQ=",
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/liferay-frontend-theme-unstyled/-/liferay-frontend-theme-unstyled-2.1.16.tgz",
+      "integrity": "sha1-KPaqFP1DqDfSwYpcKe5p8g1vdeo=",
       "dev": true
     },
     "liferay-plugin-node-tasks": {
@@ -4853,17 +5526,17 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
-          "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "^4.17.10"
           }
         },
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -4877,9 +5550,9 @@
       }
     },
     "liferay-theme-deps-6.2": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/liferay-theme-deps-6.2/-/liferay-theme-deps-6.2-0.0.5.tgz",
-      "integrity": "sha1-Uit4zsLXbzgS4gKcxmowTDiJdz8=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/liferay-theme-deps-6.2/-/liferay-theme-deps-6.2-7.0.0.tgz",
+      "integrity": "sha512-aUhbqtQLsp0A89uJm5Kj45cksMOecJcy2tdiyu/ikjjRqH5egwIGCic7eNVvoQY8gPpJFK71ZKD+tAmO3bUEFg==",
       "dev": true,
       "requires": {
         "gulp-ruby-sass": "^2.0.6",
@@ -4890,23 +5563,39 @@
       }
     },
     "liferay-theme-deps-7.0": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/liferay-theme-deps-7.0/-/liferay-theme-deps-7.0-1.2.0.tgz",
-      "integrity": "sha512-82Fwg5FgE0fQWxs1qnd2DvjiTNNsN/Zms5CzV1O43JKuhNB1EHLDPfhqYuMDW/+YSIcftynV+muN+NvAWL9I3w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/liferay-theme-deps-7.0/-/liferay-theme-deps-7.0-7.0.0.tgz",
+      "integrity": "sha512-oOvbehR4Yf0SFm7hYyapVc9aHzXkYWA5FBnaPpsSbgNQ/RfQ84Vu1yDVdy+VmCqNg9ykZ/MQC4R2eOlkgG96tQ==",
       "dev": true,
       "requires": {
         "compass-mixins": "^0.12.7",
         "gulp-sass": "~3.1.0",
         "liferay-frontend-common-css": "~1.0.4",
+        "liferay-frontend-theme-classic-web": "~2.0.0",
         "liferay-frontend-theme-styled": "~2.0.0",
         "liferay-frontend-theme-unstyled": "~2.1.0",
         "liferay-theme-deps-normalize": "*"
+      },
+      "dependencies": {
+        "gulp-sass": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.1.0.tgz",
+          "integrity": "sha1-U9xLaKH13f5EJKtMJHZVJpqLdLc=",
+          "dev": true,
+          "requires": {
+            "gulp-util": "^3.0",
+            "lodash.clonedeep": "^4.3.2",
+            "node-sass": "^4.2.0",
+            "through2": "^2.0.0",
+            "vinyl-sourcemaps-apply": "^0.2.0"
+          }
+        }
       }
     },
     "liferay-theme-deps-normalize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/liferay-theme-deps-normalize/-/liferay-theme-deps-normalize-1.0.0.tgz",
-      "integrity": "sha1-ULZ371ujG0iN8IVRBBkxZy/N3z4=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/liferay-theme-deps-normalize/-/liferay-theme-deps-normalize-7.0.0.tgz",
+      "integrity": "sha512-Mj9DrkjZdDDg2D3hBjmmvwo/uUmoD9ZChEV+ilL3I18sJiu86WC/6cDtedmkmtAKhmrsp4NqwljYm4/jdEPXUQ==",
       "dev": true
     },
     "liferay-theme-mixins": {
@@ -4928,38 +5617,37 @@
       "dev": true
     },
     "liftoff": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
-      "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
+      "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "requires": {
         "extend": "^3.0.0",
-        "findup-sync": "^0.4.2",
+        "findup-sync": "^2.0.0",
         "fined": "^1.0.1",
-        "flagged-respawn": "^0.3.2",
-        "lodash.isplainobject": "^4.0.4",
-        "lodash.isstring": "^4.0.1",
-        "lodash.mapvalues": "^4.4.0",
+        "flagged-respawn": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "object.map": "^1.0.0",
         "rechoir": "^0.6.2",
         "resolve": "^1.1.7"
       },
       "dependencies": {
         "findup-sync": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
-          "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+          "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
           "requires": {
-            "detect-file": "^0.1.0",
-            "is-glob": "^2.0.1",
-            "micromatch": "^2.3.7",
-            "resolve-dir": "^0.1.0"
+            "detect-file": "^1.0.0",
+            "is-glob": "^3.1.0",
+            "micromatch": "^3.0.4",
+            "resolve-dir": "^1.0.1"
           }
         }
       }
     },
     "livereload-js": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
-      "integrity": "sha1-bIclfmSKtHW8JOoldFftzB+NC8I="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
+      "integrity": "sha512-j1R0/FeGa64Y+NmqfZhyoVRzcFlOZ8sNlKzHjh4VvLULFACZhn68XrX5DFg2FhMvSMJmROuFxRSa560ECWKBMg=="
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -5114,11 +5802,6 @@
         "lodash.keys": "^3.0.0"
       }
     },
-    "lodash.assignwith": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
-      "integrity": "sha1-EnqX8CrcQXUalU0ksN4X4QDgOOs="
-    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -5170,11 +5853,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
-    "lodash.isempty": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
-    },
     "lodash.isobject": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
@@ -5182,16 +5860,6 @@
       "requires": {
         "lodash._objecttypes": "~2.4.1"
       }
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.keys": {
       "version": "3.1.2",
@@ -5203,21 +5871,11 @@
         "lodash.isarray": "^3.0.0"
       }
     },
-    "lodash.mapvalues": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
-    },
     "lodash.mergewith": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
-      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
       "dev": true
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.restparam": {
       "version": "3.6.1",
@@ -5294,17 +5952,25 @@
       }
     },
     "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      }
+    },
+    "make-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+      "requires": {
+        "kind-of": "^6.0.2"
       }
     },
     "map-cache": {
@@ -5322,6 +5988,14 @@
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
     },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
     "matcher": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-0.1.2.tgz",
@@ -5330,6 +6004,13 @@
       "requires": {
         "escape-string-regexp": "^1.0.4"
       }
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true,
+      "optional": true
     },
     "max-timeout": {
       "version": "1.0.0",
@@ -5432,36 +6113,36 @@
       }
     },
     "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "mime-db": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "~1.27.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-response": {
@@ -5494,6 +6175,25 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -5540,15 +6240,33 @@
       "integrity": "sha1-8JwJDTM7MGP2Fcu8ynGzSYk/AVI="
     },
     "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
       "dev": true
     },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
     "natives": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
-      "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
+      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
     },
     "nested-error-stacks": {
       "version": "1.0.2",
@@ -5572,38 +6290,79 @@
       }
     },
     "node-gyp": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
-      "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.7.0.tgz",
+      "integrity": "sha512-qDQE/Ft9xXP6zphwx4sD0t+VhwV7yFaloMpfbL2QnnDZcyaiakWlLdtFGGQfTAwpFHdpbRhRxVhIHN1OKAjgbg==",
       "dev": true,
       "requires": {
         "fstream": "^1.0.0",
         "glob": "^7.0.3",
         "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
         "mkdirp": "^0.5.0",
         "nopt": "2 || 3",
         "npmlog": "0 || 1 || 2 || 3 || 4",
         "osenv": "0",
-        "request": "2",
+        "request": ">=2.9.0 <2.82.0",
         "rimraf": "2",
         "semver": "~5.3.0",
         "tar": "^2.0.0",
         "which": "1"
       },
       "dependencies": {
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
+          }
+        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "dev": true
         }
       }
     },
     "node-sass": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
-      "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.1.tgz",
+      "integrity": "sha512-m6H1I6cHXsHsJ7BIWdnJsz9S9gVMyh+/H2cOTXgl2/2WqyyWlBcl4PHJcqrXo5RZVCfCUFqOtjPN0+0XbVHR5Q==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -5618,12 +6377,13 @@
         "lodash.mergewith": "^4.6.0",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
-        "nan": "^2.3.2",
+        "nan": "^2.10.0",
         "node-gyp": "^3.3.1",
         "npmlog": "^4.0.0",
-        "request": "^2.79.0",
-        "sass-graph": "^2.1.1",
-        "stdout-stream": "^1.4.0"
+        "request": "2.87.0",
+        "sass-graph": "^2.2.4",
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
       },
       "dependencies": {
         "cross-spawn": {
@@ -5637,29 +6397,29 @@
           }
         },
         "gaze": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-          "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+          "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
           "dev": true,
           "requires": {
             "globule": "^1.0.0"
           }
         },
         "globule": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
-          "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
+          "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
           "dev": true,
           "requires": {
             "glob": "~7.1.1",
-            "lodash": "~4.17.4",
+            "lodash": "~4.17.10",
             "minimatch": "~3.0.2"
           }
         },
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         },
         "lodash.assign": {
@@ -5685,9 +6445,9 @@
       }
     },
     "normalize-package-data": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
         "hosted-git-info": "^2.1.4",
         "is-builtin-module": "^1.0.0",
@@ -5699,6 +6459,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -5719,40 +6480,12 @@
       "requires": {
         "got": "^7.1.0",
         "registry-url": "^3.0.3"
-      },
-      "dependencies": {
-        "got": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-          "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-          "requires": {
-            "decompress-response": "^3.2.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "isurl": "^1.0.0-alpha5",
-            "lowercase-keys": "^1.0.0",
-            "p-cancelable": "^0.3.0",
-            "p-timeout": "^1.1.1",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "url-parse-lax": "^1.0.0",
-            "url-to-options": "^1.0.1"
-          }
-        },
-        "timed-out": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-        }
       }
     },
     "npmlog": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-      "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
@@ -5797,8 +6530,7 @@
       "dependencies": {
         "append-transform": {
           "version": "0.4.0",
-          "resolved": false,
-          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "default-require-extensions": "^1.0.0"
@@ -5806,14 +6538,12 @@
         },
         "arrify": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "bundled": true,
           "dev": true
         },
         "caching-transform": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "md5-hex": "^1.2.0",
@@ -5823,8 +6553,7 @@
           "dependencies": {
             "write-file-atomic": {
               "version": "1.1.4",
-              "resolved": false,
-              "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -5834,20 +6563,17 @@
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.4",
-                  "resolved": false,
-                  "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                  "bundled": true,
                   "dev": true
                 },
                 "imurmurhash": {
                   "version": "0.1.4",
-                  "resolved": false,
-                  "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+                  "bundled": true,
                   "dev": true
                 },
                 "slide": {
                   "version": "1.1.6",
-                  "resolved": false,
-                  "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -5856,14 +6582,12 @@
         },
         "convert-source-map": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-RMCMJQbxD7PKb9iI1aNETPjWpmk=",
+          "bundled": true,
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "strip-bom": "^2.0.0"
@@ -5871,8 +6595,7 @@
           "dependencies": {
             "strip-bom": {
               "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-utf8": "^0.2.0"
@@ -5880,8 +6603,7 @@
               "dependencies": {
                 "is-utf8": {
                   "version": "0.2.1",
-                  "resolved": false,
-                  "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -5890,8 +6612,7 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
@@ -5901,14 +6622,12 @@
           "dependencies": {
             "commondir": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+              "bundled": true,
               "dev": true
             },
             "pkg-dir": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "find-up": "^1.0.0"
@@ -5918,8 +6637,7 @@
         },
         "find-up": {
           "version": "1.1.2",
-          "resolved": false,
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "path-exists": "^2.0.0",
@@ -5928,8 +6646,7 @@
           "dependencies": {
             "path-exists": {
               "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "pinkie-promise": "^2.0.0"
@@ -5937,8 +6654,7 @@
             },
             "pinkie-promise": {
               "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "pinkie": "^2.0.0"
@@ -5946,8 +6662,7 @@
               "dependencies": {
                 "pinkie": {
                   "version": "2.0.4",
-                  "resolved": false,
-                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -5956,8 +6671,7 @@
         },
         "foreground-child": {
           "version": "1.5.1",
-          "resolved": false,
-          "integrity": "sha1-76NNl4DSV8dQsR4pbi4e3BT/+qo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn-async": "^2.1.1",
@@ -5967,8 +6681,7 @@
           "dependencies": {
             "cross-spawn-async": {
               "version": "2.2.4",
-              "resolved": false,
-              "integrity": "sha1-yajY6aBlAsekYpbjOhoFS10vGBI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lru-cache": "^4.0.0",
@@ -5977,8 +6690,7 @@
               "dependencies": {
                 "lru-cache": {
                   "version": "4.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "pseudomap": "^1.0.1",
@@ -5987,14 +6699,12 @@
                   "dependencies": {
                     "pseudomap": {
                       "version": "1.0.2",
-                      "resolved": false,
-                      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+                      "bundled": true,
                       "dev": true
                     },
                     "yallist": {
                       "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -6003,14 +6713,12 @@
             },
             "signal-exit": {
               "version": "2.1.2",
-              "resolved": false,
-              "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ=",
+              "bundled": true,
               "dev": true
             },
             "which": {
               "version": "1.2.10",
-              "resolved": false,
-              "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "isexe": "^1.1.1"
@@ -6018,8 +6726,7 @@
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
-                  "resolved": false,
-                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -6028,8 +6735,7 @@
         },
         "glob": {
           "version": "7.0.3",
-          "resolved": false,
-          "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inflight": "^1.0.4",
@@ -6041,8 +6747,7 @@
           "dependencies": {
             "inflight": {
               "version": "1.0.5",
-              "resolved": false,
-              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "once": "^1.3.0",
@@ -6051,22 +6756,19 @@
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+              "bundled": true,
               "dev": true
             },
             "minimatch": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "brace-expansion": "^1.0.0"
@@ -6074,8 +6776,7 @@
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.4",
-                  "resolved": false,
-                  "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "balanced-match": "^0.4.1",
@@ -6084,14 +6785,12 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.1",
-                      "resolved": false,
-                      "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU=",
+                      "bundled": true,
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "resolved": false,
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -6100,8 +6799,7 @@
             },
             "once": {
               "version": "1.3.3",
-              "resolved": false,
-              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "wrappy": "1"
@@ -6109,24 +6807,21 @@
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "istanbul": {
           "version": "0.4.3",
-          "resolved": false,
-          "integrity": "sha1-W3FO4K5JOsXvIEuZ84crzu9z1To=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "abbrev": "1.0.x",
@@ -6147,20 +6842,17 @@
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "resolved": false,
-              "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
+              "bundled": true,
               "dev": true
             },
             "async": {
               "version": "1.5.2",
-              "resolved": false,
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+              "bundled": true,
               "dev": true
             },
             "escodegen": {
               "version": "1.8.0",
-              "resolved": false,
-              "integrity": "sha1-skaq6CnOc9WeLFVyc1nt0cEwqBs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "esprima": "^2.7.1",
@@ -6172,20 +6864,17 @@
               "dependencies": {
                 "estraverse": {
                   "version": "1.9.3",
-                  "resolved": false,
-                  "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+                  "bundled": true,
                   "dev": true
                 },
                 "esutils": {
                   "version": "2.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+                  "bundled": true,
                   "dev": true
                 },
                 "optionator": {
                   "version": "0.8.1",
-                  "resolved": false,
-                  "integrity": "sha1-4xtJMs3V+4Yqiw0QvGPT7h7H14s=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "deep-is": "~0.1.3",
@@ -6198,20 +6887,17 @@
                   "dependencies": {
                     "deep-is": {
                       "version": "0.1.3",
-                      "resolved": false,
-                      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "fast-levenshtein": {
                       "version": "1.1.3",
-                      "resolved": false,
-                      "integrity": "sha1-KuezKrweYS2kik4ThJuIii9h5+k=",
+                      "bundled": true,
                       "dev": true
                     },
                     "levn": {
                       "version": "0.3.0",
-                      "resolved": false,
-                      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "prelude-ls": "~1.1.2",
@@ -6220,14 +6906,12 @@
                     },
                     "prelude-ls": {
                       "version": "1.1.2",
-                      "resolved": false,
-                      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "type-check": {
                       "version": "0.3.2",
-                      "resolved": false,
-                      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "prelude-ls": "~1.1.2"
@@ -6237,8 +6921,7 @@
                 },
                 "source-map": {
                   "version": "0.2.0",
-                  "resolved": false,
-                  "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -6247,8 +6930,7 @@
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -6258,14 +6940,12 @@
             },
             "esprima": {
               "version": "2.7.2",
-              "resolved": false,
-              "integrity": "sha1-9DvlQ2CZhOrkTJM6xjNSpq818zk=",
+              "bundled": true,
               "dev": true
             },
             "fileset": {
               "version": "0.2.1",
-              "resolved": false,
-              "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "glob": "5.x",
@@ -6274,8 +6954,7 @@
               "dependencies": {
                 "glob": {
                   "version": "5.0.15",
-                  "resolved": false,
-                  "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "inflight": "^1.0.4",
@@ -6287,8 +6966,7 @@
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.5",
-                      "resolved": false,
-                      "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "once": "^1.3.0",
@@ -6297,30 +6975,26 @@
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "resolved": false,
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "resolved": false,
-                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                      "bundled": true,
                       "dev": true
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "resolved": false,
-                  "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "brace-expansion": "^1.0.0"
@@ -6328,8 +7002,7 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.4",
-                      "resolved": false,
-                      "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "balanced-match": "^0.4.1",
@@ -6338,14 +7011,12 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.1",
-                          "resolved": false,
-                          "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU=",
+                          "bundled": true,
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -6356,8 +7027,7 @@
             },
             "handlebars": {
               "version": "4.0.5",
-              "resolved": false,
-              "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "async": "^1.4.0",
@@ -6368,8 +7038,7 @@
               "dependencies": {
                 "optimist": {
                   "version": "0.6.1",
-                  "resolved": false,
-                  "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "minimist": "~0.0.1",
@@ -6378,22 +7047,19 @@
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.10",
-                      "resolved": false,
-                      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                      "bundled": true,
                       "dev": true
                     },
                     "wordwrap": {
                       "version": "0.0.3",
-                      "resolved": false,
-                      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.4.4",
-                  "resolved": false,
-                  "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "amdefine": ">=0.0.4"
@@ -6401,16 +7067,14 @@
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "uglify-js": {
                   "version": "2.6.2",
-                  "resolved": false,
-                  "integrity": "sha1-9QvoikLNOWpiUdxSqzcvccwS/vA=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -6422,29 +7086,25 @@
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "resolved": false,
-                      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "source-map": {
                       "version": "0.5.6",
-                      "resolved": false,
-                      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "uglify-to-browserify": {
                       "version": "1.0.2",
-                      "resolved": false,
-                      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "yargs": {
                       "version": "3.10.0",
-                      "resolved": false,
-                      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -6456,15 +7116,13 @@
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "resolved": false,
-                          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "cliui": {
                           "version": "2.1.0",
-                          "resolved": false,
-                          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -6475,8 +7133,7 @@
                           "dependencies": {
                             "center-align": {
                               "version": "0.1.3",
-                              "resolved": false,
-                              "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                              "bundled": true,
                               "dev": true,
                               "optional": true,
                               "requires": {
@@ -6486,8 +7143,7 @@
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "resolved": false,
-                                  "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                                  "bundled": true,
                                   "dev": true,
                                   "optional": true,
                                   "requires": {
@@ -6498,8 +7154,7 @@
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.3",
-                                      "resolved": false,
-                                      "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
+                                      "bundled": true,
                                       "dev": true,
                                       "optional": true,
                                       "requires": {
@@ -6508,8 +7163,7 @@
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
-                                          "resolved": false,
-                                          "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
+                                          "bundled": true,
                                           "dev": true,
                                           "optional": true
                                         }
@@ -6517,15 +7171,13 @@
                                     },
                                     "longest": {
                                       "version": "1.0.1",
-                                      "resolved": false,
-                                      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                      "bundled": true,
                                       "dev": true,
                                       "optional": true
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
-                                      "resolved": false,
-                                      "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                      "bundled": true,
                                       "dev": true,
                                       "optional": true
                                     }
@@ -6533,8 +7185,7 @@
                                 },
                                 "lazy-cache": {
                                   "version": "1.0.4",
-                                  "resolved": false,
-                                  "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+                                  "bundled": true,
                                   "dev": true,
                                   "optional": true
                                 }
@@ -6542,8 +7193,7 @@
                             },
                             "right-align": {
                               "version": "0.1.3",
-                              "resolved": false,
-                              "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                              "bundled": true,
                               "dev": true,
                               "optional": true,
                               "requires": {
@@ -6552,8 +7202,7 @@
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "resolved": false,
-                                  "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                                  "bundled": true,
                                   "dev": true,
                                   "optional": true,
                                   "requires": {
@@ -6564,8 +7213,7 @@
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.3",
-                                      "resolved": false,
-                                      "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
+                                      "bundled": true,
                                       "dev": true,
                                       "optional": true,
                                       "requires": {
@@ -6574,8 +7222,7 @@
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
-                                          "resolved": false,
-                                          "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
+                                          "bundled": true,
                                           "dev": true,
                                           "optional": true
                                         }
@@ -6583,15 +7230,13 @@
                                     },
                                     "longest": {
                                       "version": "1.0.1",
-                                      "resolved": false,
-                                      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                      "bundled": true,
                                       "dev": true,
                                       "optional": true
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
-                                      "resolved": false,
-                                      "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                      "bundled": true,
                                       "dev": true,
                                       "optional": true
                                     }
@@ -6601,8 +7246,7 @@
                             },
                             "wordwrap": {
                               "version": "0.0.2",
-                              "resolved": false,
-                              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                              "bundled": true,
                               "dev": true,
                               "optional": true
                             }
@@ -6610,15 +7254,13 @@
                         },
                         "decamelize": {
                           "version": "1.2.0",
-                          "resolved": false,
-                          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "window-size": {
                           "version": "0.1.0",
-                          "resolved": false,
-                          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         }
@@ -6630,8 +7272,7 @@
             },
             "js-yaml": {
               "version": "3.6.1",
-              "resolved": false,
-              "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "argparse": "^1.0.7",
@@ -6640,8 +7281,7 @@
               "dependencies": {
                 "argparse": {
                   "version": "1.0.7",
-                  "resolved": false,
-                  "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "sprintf-js": "~1.0.2"
@@ -6649,8 +7289,7 @@
                   "dependencies": {
                     "sprintf-js": {
                       "version": "1.0.3",
-                      "resolved": false,
-                      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -6659,8 +7298,7 @@
             },
             "nopt": {
               "version": "3.0.6",
-              "resolved": false,
-              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "abbrev": "1"
@@ -6668,8 +7306,7 @@
             },
             "once": {
               "version": "1.3.3",
-              "resolved": false,
-              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "wrappy": "1"
@@ -6677,22 +7314,19 @@
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "resolve": {
               "version": "1.1.7",
-              "resolved": false,
-              "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+              "bundled": true,
               "dev": true
             },
             "supports-color": {
               "version": "3.1.2",
-              "resolved": false,
-              "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "has-flag": "^1.0.0"
@@ -6700,16 +7334,14 @@
               "dependencies": {
                 "has-flag": {
                   "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "which": {
               "version": "1.2.10",
-              "resolved": false,
-              "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "isexe": "^1.1.1"
@@ -6717,24 +7349,21 @@
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
-                  "resolved": false,
-                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "wordwrap": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "md5-hex": {
           "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "md5-o-matic": "^0.1.1"
@@ -6742,16 +7371,14 @@
           "dependencies": {
             "md5-o-matic": {
               "version": "0.1.1",
-              "resolved": false,
-              "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "micromatch": {
           "version": "2.3.8",
-          "resolved": false,
-          "integrity": "sha1-lPv4837Z7eyga/HI97dD+19vWFQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-diff": "^2.0.0",
@@ -6771,8 +7398,7 @@
           "dependencies": {
             "arr-diff": {
               "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "arr-flatten": "^1.0.1"
@@ -6780,22 +7406,19 @@
               "dependencies": {
                 "arr-flatten": {
                   "version": "1.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "array-unique": {
               "version": "0.2.1",
-              "resolved": false,
-              "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+              "bundled": true,
               "dev": true
             },
             "braces": {
               "version": "1.8.5",
-              "resolved": false,
-              "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "expand-range": "^1.8.1",
@@ -6805,8 +7428,7 @@
               "dependencies": {
                 "expand-range": {
                   "version": "1.8.2",
-                  "resolved": false,
-                  "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "fill-range": "^2.1.0"
@@ -6814,8 +7436,7 @@
                   "dependencies": {
                     "fill-range": {
                       "version": "2.2.3",
-                      "resolved": false,
-                      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "is-number": "^2.1.0",
@@ -6827,8 +7448,7 @@
                       "dependencies": {
                         "is-number": {
                           "version": "2.1.0",
-                          "resolved": false,
-                          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "kind-of": "^3.0.2"
@@ -6836,8 +7456,7 @@
                         },
                         "isobject": {
                           "version": "2.1.0",
-                          "resolved": false,
-                          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "isarray": "1.0.0"
@@ -6845,16 +7464,14 @@
                           "dependencies": {
                             "isarray": {
                               "version": "1.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "randomatic": {
                           "version": "1.1.5",
-                          "resolved": false,
-                          "integrity": "sha1-Xp718tVzxnvSuBJK6QtRVuRXhAs=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "is-number": "^2.0.2",
@@ -6863,8 +7480,7 @@
                         },
                         "repeat-string": {
                           "version": "1.5.4",
-                          "resolved": false,
-                          "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -6873,22 +7489,19 @@
                 },
                 "preserve": {
                   "version": "0.2.0",
-                  "resolved": false,
-                  "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+                  "bundled": true,
                   "dev": true
                 },
                 "repeat-element": {
                   "version": "1.1.2",
-                  "resolved": false,
-                  "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "expand-brackets": {
               "version": "0.1.5",
-              "resolved": false,
-              "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-posix-bracket": "^0.1.0"
@@ -6896,16 +7509,14 @@
               "dependencies": {
                 "is-posix-bracket": {
                   "version": "0.1.1",
-                  "resolved": false,
-                  "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "extglob": {
               "version": "0.3.2",
-              "resolved": false,
-              "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extglob": "^1.0.0"
@@ -6913,20 +7524,17 @@
             },
             "filename-regex": {
               "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
+              "bundled": true,
               "dev": true
             },
             "is-extglob": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+              "bundled": true,
               "dev": true
             },
             "is-glob": {
               "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extglob": "^1.0.0"
@@ -6934,8 +7542,7 @@
             },
             "kind-of": {
               "version": "3.0.3",
-              "resolved": false,
-              "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-buffer": "^1.0.2"
@@ -6943,22 +7550,19 @@
               "dependencies": {
                 "is-buffer": {
                   "version": "1.1.3",
-                  "resolved": false,
-                  "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "normalize-path": {
               "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o=",
+              "bundled": true,
               "dev": true
             },
             "object.omit": {
               "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-hoWXMz1U5gZilAu0WGBd1q4S/pQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "for-own": "^0.1.3",
@@ -6967,8 +7571,7 @@
               "dependencies": {
                 "for-own": {
                   "version": "0.1.4",
-                  "resolved": false,
-                  "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "for-in": "^0.1.5"
@@ -6976,24 +7579,21 @@
                   "dependencies": {
                     "for-in": {
                       "version": "0.1.5",
-                      "resolved": false,
-                      "integrity": "sha1-AHN04rbVxnQgoUeb23WgSHK3OMQ=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "is-extendable": {
                   "version": "0.1.1",
-                  "resolved": false,
-                  "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "parse-glob": {
               "version": "3.0.4",
-              "resolved": false,
-              "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "glob-base": "^0.3.0",
@@ -7004,8 +7604,7 @@
               "dependencies": {
                 "glob-base": {
                   "version": "0.3.0",
-                  "resolved": false,
-                  "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "glob-parent": "^2.0.0",
@@ -7014,8 +7613,7 @@
                   "dependencies": {
                     "glob-parent": {
                       "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "is-glob": "^2.0.0"
@@ -7025,16 +7623,14 @@
                 },
                 "is-dotfile": {
                   "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "regex-cache": {
               "version": "0.4.3",
-              "resolved": false,
-              "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-equal-shallow": "^0.1.3",
@@ -7043,8 +7639,7 @@
               "dependencies": {
                 "is-equal-shallow": {
                   "version": "0.1.3",
-                  "resolved": false,
-                  "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-primitive": "^2.0.0"
@@ -7052,8 +7647,7 @@
                 },
                 "is-primitive": {
                   "version": "2.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -7062,8 +7656,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -7071,16 +7664,14 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": false,
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "pkg-up": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "find-up": "^1.0.0"
@@ -7088,14 +7679,12 @@
         },
         "resolve-from": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "bundled": true,
           "dev": true
         },
         "rimraf": {
           "version": "2.5.2",
-          "resolved": false,
-          "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.0.0"
@@ -7103,20 +7692,17 @@
         },
         "signal-exit": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-PAVDtl17T7xgts2UWT2b9DZzm+g=",
+          "bundled": true,
           "dev": true
         },
         "source-map": {
           "version": "0.5.6",
-          "resolved": false,
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "bundled": true,
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.2.3",
-          "resolved": false,
-          "integrity": "sha1-3300R/tKAZYZpB9o7mQqcY5gYuk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "foreground-child": "^1.3.3",
@@ -7129,20 +7715,17 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
+              "bundled": true,
               "dev": true
             },
             "signal-exit": {
               "version": "2.1.2",
-              "resolved": false,
-              "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ=",
+              "bundled": true,
               "dev": true
             },
             "which": {
               "version": "1.2.10",
-              "resolved": false,
-              "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "isexe": "^1.1.1"
@@ -7150,8 +7733,7 @@
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
-                  "resolved": false,
-                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -7160,8 +7742,7 @@
         },
         "test-exclude": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-9d3XGJJ7Ev0C8nCgqpOc627qQVE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arrify": "^1.0.1",
@@ -7173,8 +7754,7 @@
           "dependencies": {
             "lodash.assign": {
               "version": "4.0.9",
-              "resolved": false,
-              "integrity": "sha1-Cgcx2TWQ3dm6RYn61lqvbuCSF+M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lodash.keys": "^4.0.0",
@@ -7183,22 +7763,19 @@
               "dependencies": {
                 "lodash.keys": {
                   "version": "4.0.7",
-                  "resolved": false,
-                  "integrity": "sha1-MOGzvZjlTWoGEZkYEmhba8R8tjs=",
+                  "bundled": true,
                   "dev": true
                 },
                 "lodash.rest": {
                   "version": "4.0.3",
-                  "resolved": false,
-                  "integrity": "sha1-TBwyxAAoCHJQ+r9w1C4BUVSPSMU=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "read-pkg-up": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "find-up": "^1.0.0",
@@ -7207,8 +7784,7 @@
               "dependencies": {
                 "read-pkg": {
                   "version": "1.1.0",
-                  "resolved": false,
-                  "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "load-json-file": "^1.0.0",
@@ -7218,8 +7794,7 @@
                   "dependencies": {
                     "load-json-file": {
                       "version": "1.1.0",
-                      "resolved": false,
-                      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "graceful-fs": "^4.1.2",
@@ -7231,14 +7806,12 @@
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
-                          "resolved": false,
-                          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                          "bundled": true,
                           "dev": true
                         },
                         "parse-json": {
                           "version": "2.2.0",
-                          "resolved": false,
-                          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "error-ex": "^1.2.0"
@@ -7246,8 +7819,7 @@
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.0",
-                              "resolved": false,
-                              "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "is-arrayish": "^0.2.1"
@@ -7255,8 +7827,7 @@
                               "dependencies": {
                                 "is-arrayish": {
                                   "version": "0.2.1",
-                                  "resolved": false,
-                                  "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+                                  "bundled": true,
                                   "dev": true
                                 }
                               }
@@ -7265,14 +7836,12 @@
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "resolved": false,
-                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                          "bundled": true,
                           "dev": true
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "pinkie": "^2.0.0"
@@ -7280,16 +7849,14 @@
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "resolved": false,
-                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "strip-bom": {
                           "version": "2.0.0",
-                          "resolved": false,
-                          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "is-utf8": "^0.2.0"
@@ -7297,8 +7864,7 @@
                           "dependencies": {
                             "is-utf8": {
                               "version": "0.2.1",
-                              "resolved": false,
-                              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -7307,8 +7873,7 @@
                     },
                     "normalize-package-data": {
                       "version": "2.3.5",
-                      "resolved": false,
-                      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "hosted-git-info": "^2.1.4",
@@ -7319,14 +7884,12 @@
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.5",
-                          "resolved": false,
-                          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
+                          "bundled": true,
                           "dev": true
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
-                          "resolved": false,
-                          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "builtin-modules": "^1.0.0"
@@ -7334,22 +7897,19 @@
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.1",
-                              "resolved": false,
-                              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "semver": {
                           "version": "5.1.0",
-                          "resolved": false,
-                          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+                          "bundled": true,
                           "dev": true
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "spdx-correct": "~1.0.0",
@@ -7358,8 +7918,7 @@
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
-                              "resolved": false,
-                              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "spdx-license-ids": "^1.0.2"
@@ -7367,16 +7926,14 @@
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "resolved": false,
-                                  "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM=",
+                                  "bundled": true,
                                   "dev": true
                                 }
                               }
                             },
                             "spdx-expression-parse": {
                               "version": "1.0.2",
-                              "resolved": false,
-                              "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "spdx-exceptions": "^1.0.4",
@@ -7385,14 +7942,12 @@
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.4",
-                                  "resolved": false,
-                                  "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
+                                  "bundled": true,
                                   "dev": true
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "resolved": false,
-                                  "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM=",
+                                  "bundled": true,
                                   "dev": true
                                 }
                               }
@@ -7403,8 +7958,7 @@
                     },
                     "path-type": {
                       "version": "1.1.0",
-                      "resolved": false,
-                      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "graceful-fs": "^4.1.2",
@@ -7414,20 +7968,17 @@
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
-                          "resolved": false,
-                          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                          "bundled": true,
                           "dev": true
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "resolved": false,
-                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                          "bundled": true,
                           "dev": true
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "pinkie": "^2.0.0"
@@ -7435,8 +7986,7 @@
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "resolved": false,
-                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -7449,16 +7999,14 @@
             },
             "require-main-filename": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "yargs": {
           "version": "4.7.1",
-          "resolved": false,
-          "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "camelcase": "^3.0.0",
@@ -7478,14 +8026,12 @@
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+              "bundled": true,
               "dev": true
             },
             "cliui": {
               "version": "3.2.0",
-              "resolved": false,
-              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "string-width": "^1.0.1",
@@ -7495,8 +8041,7 @@
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
@@ -7504,16 +8049,14 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "wrap-ansi": {
                   "version": "2.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-fTD4+HP5pbvDpk2ryNF34HGuQm8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "string-width": "^1.0.1"
@@ -7523,14 +8066,12 @@
             },
             "decamelize": {
               "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+              "bundled": true,
               "dev": true
             },
             "lodash.assign": {
               "version": "4.0.9",
-              "resolved": false,
-              "integrity": "sha1-Cgcx2TWQ3dm6RYn61lqvbuCSF+M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lodash.keys": "^4.0.0",
@@ -7539,22 +8080,19 @@
               "dependencies": {
                 "lodash.keys": {
                   "version": "4.0.7",
-                  "resolved": false,
-                  "integrity": "sha1-MOGzvZjlTWoGEZkYEmhba8R8tjs=",
+                  "bundled": true,
                   "dev": true
                 },
                 "lodash.rest": {
                   "version": "4.0.3",
-                  "resolved": false,
-                  "integrity": "sha1-TBwyxAAoCHJQ+r9w1C4BUVSPSMU=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "os-locale": {
               "version": "1.4.0",
-              "resolved": false,
-              "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lcid": "^1.0.0"
@@ -7562,8 +8100,7 @@
               "dependencies": {
                 "lcid": {
                   "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "invert-kv": "^1.0.0"
@@ -7571,8 +8108,7 @@
                   "dependencies": {
                     "invert-kv": {
                       "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -7581,8 +8117,7 @@
             },
             "pkg-conf": {
               "version": "1.1.3",
-              "resolved": false,
-              "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "find-up": "^1.0.0",
@@ -7593,8 +8128,7 @@
               "dependencies": {
                 "load-json-file": {
                   "version": "1.1.0",
-                  "resolved": false,
-                  "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "graceful-fs": "^4.1.2",
@@ -7606,14 +8140,12 @@
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.4",
-                      "resolved": false,
-                      "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                      "bundled": true,
                       "dev": true
                     },
                     "parse-json": {
                       "version": "2.2.0",
-                      "resolved": false,
-                      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "error-ex": "^1.2.0"
@@ -7621,8 +8153,7 @@
                       "dependencies": {
                         "error-ex": {
                           "version": "1.3.0",
-                          "resolved": false,
-                          "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "is-arrayish": "^0.2.1"
@@ -7630,8 +8161,7 @@
                           "dependencies": {
                             "is-arrayish": {
                               "version": "0.2.1",
-                              "resolved": false,
-                              "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -7640,14 +8170,12 @@
                     },
                     "pify": {
                       "version": "2.3.0",
-                      "resolved": false,
-                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                      "bundled": true,
                       "dev": true
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "resolved": false,
-                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "pinkie": "^2.0.0"
@@ -7655,16 +8183,14 @@
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "resolved": false,
-                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "strip-bom": {
                       "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "is-utf8": "^0.2.0"
@@ -7672,8 +8198,7 @@
                       "dependencies": {
                         "is-utf8": {
                           "version": "0.2.1",
-                          "resolved": false,
-                          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -7682,22 +8207,19 @@
                 },
                 "object-assign": {
                   "version": "4.1.0",
-                  "resolved": false,
-                  "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+                  "bundled": true,
                   "dev": true
                 },
                 "symbol": {
                   "version": "0.2.3",
-                  "resolved": false,
-                  "integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "read-pkg-up": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "find-up": "^1.0.0",
@@ -7706,8 +8228,7 @@
               "dependencies": {
                 "read-pkg": {
                   "version": "1.1.0",
-                  "resolved": false,
-                  "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "load-json-file": "^1.0.0",
@@ -7717,8 +8238,7 @@
                   "dependencies": {
                     "load-json-file": {
                       "version": "1.1.0",
-                      "resolved": false,
-                      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "graceful-fs": "^4.1.2",
@@ -7730,14 +8250,12 @@
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
-                          "resolved": false,
-                          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                          "bundled": true,
                           "dev": true
                         },
                         "parse-json": {
                           "version": "2.2.0",
-                          "resolved": false,
-                          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "error-ex": "^1.2.0"
@@ -7745,8 +8263,7 @@
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.0",
-                              "resolved": false,
-                              "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "is-arrayish": "^0.2.1"
@@ -7754,8 +8271,7 @@
                               "dependencies": {
                                 "is-arrayish": {
                                   "version": "0.2.1",
-                                  "resolved": false,
-                                  "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+                                  "bundled": true,
                                   "dev": true
                                 }
                               }
@@ -7764,14 +8280,12 @@
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "resolved": false,
-                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                          "bundled": true,
                           "dev": true
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "pinkie": "^2.0.0"
@@ -7779,16 +8293,14 @@
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "resolved": false,
-                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "strip-bom": {
                           "version": "2.0.0",
-                          "resolved": false,
-                          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "is-utf8": "^0.2.0"
@@ -7796,8 +8308,7 @@
                           "dependencies": {
                             "is-utf8": {
                               "version": "0.2.1",
-                              "resolved": false,
-                              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -7806,8 +8317,7 @@
                     },
                     "normalize-package-data": {
                       "version": "2.3.5",
-                      "resolved": false,
-                      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "hosted-git-info": "^2.1.4",
@@ -7818,14 +8328,12 @@
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.5",
-                          "resolved": false,
-                          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
+                          "bundled": true,
                           "dev": true
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
-                          "resolved": false,
-                          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "builtin-modules": "^1.0.0"
@@ -7833,22 +8341,19 @@
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.1",
-                              "resolved": false,
-                              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "semver": {
                           "version": "5.1.0",
-                          "resolved": false,
-                          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+                          "bundled": true,
                           "dev": true
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "spdx-correct": "~1.0.0",
@@ -7857,8 +8362,7 @@
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
-                              "resolved": false,
-                              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "spdx-license-ids": "^1.0.2"
@@ -7866,16 +8370,14 @@
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "resolved": false,
-                                  "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM=",
+                                  "bundled": true,
                                   "dev": true
                                 }
                               }
                             },
                             "spdx-expression-parse": {
                               "version": "1.0.2",
-                              "resolved": false,
-                              "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "spdx-exceptions": "^1.0.4",
@@ -7884,14 +8386,12 @@
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.4",
-                                  "resolved": false,
-                                  "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
+                                  "bundled": true,
                                   "dev": true
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "resolved": false,
-                                  "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM=",
+                                  "bundled": true,
                                   "dev": true
                                 }
                               }
@@ -7902,8 +8402,7 @@
                     },
                     "path-type": {
                       "version": "1.1.0",
-                      "resolved": false,
-                      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "graceful-fs": "^4.1.2",
@@ -7913,20 +8412,17 @@
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
-                          "resolved": false,
-                          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                          "bundled": true,
                           "dev": true
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "resolved": false,
-                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                          "bundled": true,
                           "dev": true
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "pinkie": "^2.0.0"
@@ -7934,8 +8430,7 @@
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "resolved": false,
-                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -7948,20 +8443,17 @@
             },
             "require-main-filename": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+              "bundled": true,
               "dev": true
             },
             "set-blocking": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-zV5dk4BI3xrJLf6S4fFq3WVvXsU=",
+              "bundled": true,
               "dev": true
             },
             "string-width": {
               "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -7971,8 +8463,7 @@
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "number-is-nan": "^1.0.0"
@@ -7980,16 +8471,14 @@
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "number-is-nan": "^1.0.0"
@@ -7997,16 +8486,14 @@
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
@@ -8014,8 +8501,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -8024,20 +8510,17 @@
             },
             "window-size": {
               "version": "0.2.0",
-              "resolved": false,
-              "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+              "bundled": true,
               "dev": true
             },
             "y18n": {
               "version": "3.2.1",
-              "resolved": false,
-              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+              "bundled": true,
               "dev": true
             },
             "yargs-parser": {
               "version": "2.4.0",
-              "resolved": false,
-              "integrity": "sha1-HzZ9ycbPpWYLaXEjDzsnf8Xjrco=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "camelcase": "^2.1.1",
@@ -8046,8 +8529,7 @@
               "dependencies": {
                 "camelcase": {
                   "version": "2.1.1",
-                  "resolved": false,
-                  "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -8067,13 +8549,91 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
       "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
     },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.defaults": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "requires": {
+        "array-each": "^1.0.1",
+        "array-slice": "^1.0.0",
+        "for-own": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "requires": {
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      }
+    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "for-own": "^0.1.4",
         "is-extendable": "^0.1.1"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "for-in": "^1.0.1"
+          }
+        }
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "requires": {
+        "isobject": "^3.0.1"
       }
     },
     "observable-to-promise": {
@@ -8104,7 +8664,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "optimist": {
@@ -8148,6 +8708,24 @@
         "end-of-stream": "~0.1.5",
         "sequencify": "~0.0.7",
         "stream-consume": "~0.1.0"
+      },
+      "dependencies": {
+        "end-of-stream": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+          "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+          "requires": {
+            "once": "~1.3.0"
+          }
+        },
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "requires": {
+            "wrappy": "1"
+          }
+        }
       }
     },
     "ordered-read-streams": {
@@ -8180,9 +8758,9 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -8249,11 +8827,11 @@
       }
     },
     "parse-filepath": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
-      "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "requires": {
-        "is-absolute": "^0.2.3",
+        "is-absolute": "^1.0.0",
         "map-cache": "^0.2.0",
         "path-root": "^0.1.1"
       }
@@ -8262,11 +8840,31 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "glob-base": "^0.3.0",
         "is-dotfile": "^1.0.0",
         "is-extglob": "^1.0.0",
         "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
       }
     },
     "parse-json": {
@@ -8289,9 +8887,14 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
     "parseurl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "path-exists": {
       "version": "2.1.0",
@@ -8439,23 +9042,28 @@
         "irregular-plurals": "^1.0.0"
       }
     },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    },
     "power-assert-context-formatter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz",
-      "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.2.0.tgz",
+      "integrity": "sha512-HLNEW8Bin+BFCpk/zbyKwkEu9W8/zThIStxGo7weYcFkKgMuGCHUJhvJeBGXDZf0Qm2xis4pbnnciGZiX0EpSg==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
-        "power-assert-context-traversal": "^1.1.1"
+        "power-assert-context-traversal": "^1.2.0"
       }
     },
     "power-assert-context-reducer-ast": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.1.2.tgz",
-      "integrity": "sha1-SEqZ4m9Jc/+IMuXFzHVnAuYJQXQ=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.2.0.tgz",
+      "integrity": "sha512-EgOxmZ/Lb7tw4EwSKX7ZnfC0P/qRZFEG28dx/690qvhmOJ6hgThYFm5TUWANDLK5NiNKlPBi5WekVGd2+5wPrw==",
       "dev": true,
       "requires": {
-        "acorn": "^4.0.0",
+        "acorn": "^5.0.0",
         "acorn-es7-plugin": "^1.0.12",
         "core-js": "^2.0.0",
         "espurify": "^1.6.0",
@@ -8463,9 +9071,9 @@
       }
     },
     "power-assert-context-traversal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.1.1.tgz",
-      "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.2.0.tgz",
+      "integrity": "sha512-NFoHU6g2umNajiP2l4qb0BRWD773Aw9uWdWYH9EQsVwIZnog5bd2YYLFCVvaxWpwNzWeEfZIon2xtyc63026pQ==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
@@ -8488,13 +9096,13 @@
       }
     },
     "power-assert-renderer-assertion": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.1.1.tgz",
-      "integrity": "sha1-y/wOd+AIao+Wrz8djme57n4ozpg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.2.0.tgz",
+      "integrity": "sha512-3F7Q1ZLmV2ZCQv7aV7NJLNK9G7QsostrhOU7U0RhEQS/0vhEqrRg2jEJl1jtUL4ZyL2dXUlaaqrmPv5r9kRvIg==",
       "dev": true,
       "requires": {
         "power-assert-renderer-base": "^1.1.1",
-        "power-assert-util-string-width": "^1.1.1"
+        "power-assert-util-string-width": "^1.2.0"
       }
     },
     "power-assert-renderer-base": {
@@ -8504,9 +9112,9 @@
       "dev": true
     },
     "power-assert-renderer-comparison": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.1.1.tgz",
-      "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.2.0.tgz",
+      "integrity": "sha512-7c3RKPDBKK4E3JqdPtYRE9cM8AyX4LC4yfTvvTYyx8zSqmT5kJnXwzR0yWQLOavACllZfwrAGQzFiXPc5sWa+g==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
@@ -8517,34 +9125,34 @@
       }
     },
     "power-assert-renderer-diagram": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.1.2.tgz",
-      "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.2.0.tgz",
+      "integrity": "sha512-JZ6PC+DJPQqfU6dwSmpcoD7gNnb/5U77bU5KgNwPPa+i1Pxiz6UuDeM3EUBlhZ1HvH9tMjI60anqVyi5l2oNdg==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
         "power-assert-renderer-base": "^1.1.1",
-        "power-assert-util-string-width": "^1.1.1",
+        "power-assert-util-string-width": "^1.2.0",
         "stringifier": "^1.3.0"
       }
     },
     "power-assert-renderer-file": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.1.1.tgz",
-      "integrity": "sha1-o34rvReMys0E5427eckv40kzxec=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.2.0.tgz",
+      "integrity": "sha512-/oaVrRbeOtGoyyd7e4IdLP/jIIUFJdqJtsYzP9/88R39CMnfF/S/rUc8ZQalENfUfQ/wQHu+XZYRMaCEZmEesg==",
       "dev": true,
       "requires": {
         "power-assert-renderer-base": "^1.1.1"
       }
     },
     "power-assert-renderer-succinct": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-succinct/-/power-assert-renderer-succinct-1.1.1.tgz",
-      "integrity": "sha1-wqRosjgiq9b4Diq6UyI0ewnfR24=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-succinct/-/power-assert-renderer-succinct-1.2.0.tgz",
+      "integrity": "sha512-1fCYeYVIGPoMISnAmPjPeAs1PASR8n2lXXJR/wVLuhtWRRfvDaAyktOcRWcES7fNsmn9GQULraom5UDfEGQ8fg==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
-        "power-assert-renderer-diagram": "^1.1.1"
+        "power-assert-renderer-diagram": "^1.2.0"
       }
     },
     "power-assert-renderers": {
@@ -8561,12 +9169,12 @@
       }
     },
     "power-assert-util-string-width": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.1.1.tgz",
-      "integrity": "sha1-vmWet5N/3S5smncmjar2S9W3xZI=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.2.0.tgz",
+      "integrity": "sha512-lX90G0igAW0iyORTILZ/QjZWsa1MZ6VVY3L0K86e2eKun3S4LKPH4xZIl8fdeMYLfOjkaszbNSzf1uugLeAm2A==",
       "dev": true,
       "requires": {
-        "eastasianwidth": "^0.1.1"
+        "eastasianwidth": "^0.2.0"
       }
     },
     "prepend-http": {
@@ -8577,7 +9185,9 @@
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true,
+      "optional": true
     },
     "pretty-hrtime": {
       "version": "1.0.3",
@@ -8610,15 +9220,15 @@
       "dev": true
     },
     "private": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -8637,39 +9247,23 @@
       "integrity": "sha1-EIirr53MCuWuRbcJ5sa1iIsjkjw="
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+      "dev": true,
+      "optional": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8691,11 +9285,11 @@
       }
     },
     "rc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "~0.4.0",
+        "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
@@ -8730,16 +9324,16 @@
       }
     },
     "readable-stream": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-      "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
+        "inherits": "~2.0.3",
         "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "safe-buffer": "~5.0.1",
-        "string_decoder": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
     },
@@ -8791,21 +9385,21 @@
       }
     },
     "regenerate": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regenerator-transform": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-      "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.18.0",
@@ -8814,12 +9408,22 @@
       }
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true,
+      "optional": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3",
-        "is-primitive": "^2.0.0"
+        "is-equal-shallow": "^0.1.3"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexpu-core": {
@@ -8834,9 +9438,9 @@
       }
     },
     "registry-auth-token": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "requires": {
         "rc": "^1.1.6",
         "safe-buffer": "^5.0.1"
@@ -8874,9 +9478,9 @@
       }
     },
     "remove-trailing-separator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
       "version": "1.1.2",
@@ -8902,45 +9506,111 @@
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.6.0",
-        "aws4": "^1.2.1",
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
         "caseless": "~0.12.0",
         "combined-stream": "~1.0.5",
-        "extend": "~3.0.0",
+        "extend": "~3.0.1",
         "forever-agent": "~0.6.1",
-        "form-data": "~2.1.1",
-        "har-validator": "~4.2.1",
-        "hawk": "~3.1.3",
-        "http-signature": "~1.1.0",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.7",
-        "oauth-sign": "~0.8.1",
-        "performance-now": "^0.2.0",
-        "qs": "~6.4.0",
-        "safe-buffer": "^5.0.1",
-        "stringstream": "~0.0.4",
-        "tough-cookie": "~2.3.0",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
         "tunnel-agent": "^0.6.0",
-        "uuid": "^3.0.0"
+        "uuid": "^3.1.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+          "dev": true
+        },
         "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
         },
         "uuid": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
           "dev": true
         }
       }
@@ -8963,9 +9633,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "requires": {
         "path-parse": "^1.0.5"
       }
@@ -8980,12 +9650,12 @@
       }
     },
     "resolve-dir": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "requires": {
-        "expand-tilde": "^1.2.2",
-        "global-modules": "^0.2.3"
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -8993,6 +9663,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
       "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "restore-cursor": {
       "version": "1.0.1",
@@ -9003,10 +9678,15 @@
         "onetime": "^1.0.0"
       }
     },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "^7.0.5"
       }
@@ -9044,9 +9724,23 @@
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
     },
     "safe-buffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "samsam": {
       "version": "1.1.2",
@@ -9067,17 +9761,17 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         }
       }
     },
     "sax": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz",
-      "integrity": "sha1-/YYxojvHgmvvXYcb24c3jJVkeCg="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scss-tokenizer": {
       "version": "0.2.3",
@@ -9114,9 +9808,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
         }
       }
     },
@@ -9135,6 +9829,27 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -9190,6 +9905,108 @@
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
@@ -9216,27 +10033,44 @@
         "amdefine": ">=0.0.4"
       }
     },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
     "source-map-support": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
         "source-map": "^0.5.6"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
     },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
     "sparkles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+      "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
     },
     "spawn-sync": {
       "version": "1.0.15",
@@ -9248,22 +10082,32 @@
       }
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
-        "spdx-license-ids": "^1.0.2"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+    },
     "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
     },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
     },
     "split": {
       "version": "0.3.3",
@@ -9273,15 +10117,23 @@
         "through": "2"
       }
     },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -9291,6 +10143,7 @@
         "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
         "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
       "dependencies": {
@@ -9308,10 +10161,29 @@
       "integrity": "sha1-lAy4L8z6hOj/Lz/fKT/ngBa+zNE=",
       "dev": true
     },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
     "statuses": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stdout-stream": {
       "version": "1.4.0",
@@ -9331,9 +10203,9 @@
       }
     },
     "stream-consume": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
-      "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
+      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg=="
     },
     "stream-shift": {
       "version": "1.0.0",
@@ -9356,11 +10228,11 @@
       }
     },
     "string_decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.0.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringifier": {
@@ -9384,9 +10256,9 @@
       }
     },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
       "dev": true
     },
     "strip-ansi": {
@@ -9564,9 +10436,9 @@
       "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
     },
     "timed-out": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
-      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -9579,10 +10451,48 @@
       "resolved": "https://registry.npmjs.org/to-int/-/to-int-0.1.0.tgz",
       "integrity": "sha1-OuACfPEcfyI3+DADtj77dkMVYW0="
     },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
         "punycode": "^1.4.1"
@@ -9604,6 +10514,30 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "true-case-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
+      "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
+      "dev": true,
+      "requires": {
+        "glob": "^6.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -9628,12 +10562,12 @@
       "dev": true
     },
     "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.15"
+        "mime-types": "~2.1.18"
       }
     },
     "type-name": {
@@ -9686,6 +10620,38 @@
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
+          }
+        }
+      }
+    },
     "unique-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
@@ -9707,6 +10673,42 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+        }
+      }
+    },
     "unzip-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
@@ -9727,6 +10729,11 @@
         "xdg-basedir": "^2.0.0"
       }
     },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -9740,26 +10747,26 @@
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
+    "use": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
+    },
     "user-home": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
     },
     "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.11.0.tgz",
+      "integrity": "sha512-5n12uMzKCjvB2HPFHnbQSjaqAa98L5iIXmHrZCLavuZVe0qe/SJGbDGWlpaHk5lnBkWRDO+dRu1/PgmUYKPPTw==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        }
+        "inherits": "2.0.3"
       }
     },
     "util-deprecate": {
@@ -9781,33 +10788,42 @@
       }
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "requires": {
-        "spdx-correct": "~1.0.0",
-        "spdx-expression-parse": "~1.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "extsprintf": "1.0.2"
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
       }
     },
     "vinyl": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
-      "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+      "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
       "requires": {
-        "clone": "^1.0.0",
+        "clone": "^2.1.1",
         "clone-buffer": "^1.0.0",
         "clone-stats": "^1.0.0",
         "cloneable-readable": "^1.0.0",
-        "is-stream": "^1.1.0",
         "remove-trailing-separator": "^1.0.1",
         "replace-ext": "^1.0.0"
       }
@@ -9945,30 +10961,31 @@
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
     },
     "websocket-driver": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-      "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "requires": {
+        "http-parser-js": ">=0.4.0",
         "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
-      "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec="
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
     },
     "which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -9980,12 +10997,12 @@
       "dev": true
     },
     "wide-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.2"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "widest-line": {
@@ -10067,28 +11084,18 @@
       }
     },
     "xml2js": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "^4.1.0"
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-      "requires": {
-        "lodash": "^4.0.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        }
-      }
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.1",
@@ -10153,9 +11160,9 @@
       }
     },
     "yazl": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.2.tgz",
-      "integrity": "sha1-FMsZCD4eJacAksFYiqvg9OTdTYg=",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
+      "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
       "requires": {
         "buffer-crc32": "~0.2.3"
       }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "lodash": "^3.10.0",
     "minimist": "^1.1.0",
     "node-bourbon": "4.2.3",
-    "npm-keyword": "^4.2.0",
+    "npm-keyword": "^5.0.0",
     "package-json": "^1.2.0",
     "resolve": "^1.1.7",
     "run-sequence": "^1.0.2",


### PR DESCRIPTION
This PR wants to solve #87. There were some validations missing in case of packages with multiple versions, and one dependency had to be upgraded.